### PR TITLE
Fix WalletConnect crash

### DIFF
--- a/ConcordiumWallet/Features/WalletConnect/SessionRequestFlow/DataModels/SimpleTrasferRequestModel.swift
+++ b/ConcordiumWallet/Features/WalletConnect/SessionRequestFlow/DataModels/SimpleTrasferRequestModel.swift
@@ -52,7 +52,7 @@ final class SimpleTrasferRequestModel: SessionRequestDataProvidable {
         let params = try sessionRequest.params.get(SimpleTransferRequestParams.self)
         let transfer = getTransfer(for: params, txCost: txCost)
         let result = try await createAndPerform(params: params, account: account, transfer: transfer).singleOutput()
-        try await Web3Wallet.instance.respond(
+        try await Sign.instance.respond(
             topic: sessionRequest.topic,
             requestId: sessionRequest.id,
             response: .response(AnyCodable(["hash": result]))

--- a/ConcordiumWallet/Features/WalletConnect/SessionRequestFlow/SessionRequestViewModel.swift
+++ b/ConcordiumWallet/Features/WalletConnect/SessionRequestFlow/SessionRequestViewModel.swift
@@ -93,7 +93,7 @@ final class SessionRequestViewModel: ObservableObject {
     @MainActor
     func rejectRequest(_ completion: () -> Void) async {
         do {
-            try await Web3Wallet.instance.respond(
+            try await Sign.instance.respond(
                 topic: sessionRequest.topic,
                 requestId: sessionRequest.id,
                 response: .error(.init(code: 0, message: ""))


### PR DESCRIPTION
## Purpose

Signing should be declined which would be shown in the frontend of the dApp.
Wallet shouldn't crush but should keep working and route back to accounts overview.

## Changes

Removed Web3Wallet instance usage
