### PR TITLE
Clear error message after entering wrong password

### DIFF
--- a/ConcordiumWallet/Features/Login/Login.storyboard
+++ b/ConcordiumWallet/Features/Login/Login.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/ConcordiumWallet/Features/Login/PasswordViews/PasswordFieldViewController.swift
+++ b/ConcordiumWallet/Features/Login/PasswordViews/PasswordFieldViewController.swift
@@ -12,6 +12,11 @@ import Combine
 protocol PasswordFieldDelegate: AnyObject {
     func passwordView(_ passwordView: PasswordFieldViewController, didFinishEnteringPassword: String)
     func setPasswordState(valid: Bool)
+    func editingChanged()
+}
+
+extension PasswordFieldDelegate {
+    func editingChanged() {}
 }
 
 class PasswordFieldViewController: UIViewController, Storyboarded {
@@ -20,7 +25,7 @@ class PasswordFieldViewController: UIViewController, Storyboarded {
 
     @IBOutlet weak var passwordTextField: UITextField!
     private var cancellables: [AnyCancellable] = []
-
+    
     func getPassword() -> String? {
         passwordTextField.text
     }
@@ -57,5 +62,10 @@ extension PasswordFieldViewController: UITextFieldDelegate {
 
     private func passwordValid(_ password: String?) -> Bool {
         return (password?.count ?? 0) >= leastPasswordSize
+    }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        delegate?.editingChanged()
+        return true
     }
 }

--- a/ConcordiumWallet/Features/Login/PasswordViews/RequestExportPasswordPresenter.swift
+++ b/ConcordiumWallet/Features/Login/PasswordViews/RequestExportPasswordPresenter.swift
@@ -71,6 +71,10 @@ extension RequestExportPasswordPresenter: PasswordFieldDelegate {
     func passwordView(_ passwordView: PasswordFieldViewController, didFinishEnteringPassword password: String) {
         passwordEntered(password: password)
     }
+    
+    func editingChanged() {
+        view?.showError("")
+    }
 }
 
 extension RequestExportPasswordPresenter: PasscodeFieldDelegate {

--- a/ConcordiumWallet/Features/Login/PasswordViews/RequestPasswordPresenter.swift
+++ b/ConcordiumWallet/Features/Login/PasswordViews/RequestPasswordPresenter.swift
@@ -101,7 +101,7 @@ extension RequestPasswordPresenter: PasscodeFieldDelegate {
     }
 }
 
-extension RequestPasswordPresenter: PasswordFieldDelegate {
+extension RequestPasswordPresenter: PasswordFieldDelegate {    
     func setPasswordState(valid: Bool) {
         self.view?.setContinueButtonEnabled(valid)
     }


### PR DESCRIPTION
## Changes

while restoring wallet from file, app don't clear error message after re-entering password. we should clear error message before each new try

