### PR TITLE
Strange appearance in the transaction log

### DIFF
--- a/ConcordiumWallet/Resources/en.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/en.lproj/Localizable.strings
@@ -325,6 +325,8 @@ process on-chain.";
 "transactions.shieledtransactionfee" = "Shielded transaction fee";
 "transaction.shieldedAmount" = "Shielded amount";
 "transaction.unshieldedAmount" = "Unshielded amount";
+"transaction.configuredelegation" = "Configure delegation";
+"transaction.configurebaker" = "Configure validator";
 
 "accountDetails.generalbalance" = "Balance";
 "accountDetails.generalshieldedbalance" = "Shielded Balance";


### PR DESCRIPTION
## Purpose

Make UI great again

## Changes

Add missed localise keys:
```
"transaction.configuredelegation" = "Configure delegation";
"transaction.configurebaker" = "Configure validator";
```
