### PR TITLE
Exported account keys inconsistency

### DIFF
--- a/ConcordiumWallet/Model/Database/Environment.swift
+++ b/ConcordiumWallet/Model/Database/Environment.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 enum Environment: String, Codable {
-    case main = "production"
-    case test = "prod_testnet"
+    case mainnet = "mainnet"
+    case testnet = "testnet"
     case staging = "staging"
     case mock = "mock"
     
@@ -19,9 +19,9 @@ enum Environment: String, Codable {
         if UserDefaults.bool(forKey: "demomode.userdefaultskey".localized) == true {
             return .test
         }
-        return .main
+        return .mainnet
         #elseif TESTNET
-        return .test
+        return .testnet
         #elseif STAGINGNET
         return .staging
         #else // Mock

--- a/ConcordiumWallet/Model/Net.swift
+++ b/ConcordiumWallet/Model/Net.swift
@@ -9,17 +9,20 @@
 import Foundation
 
 enum Net: String, Codable {
-    case main = "Mainnet"
-    case test = "Testnet"
+    case mainnet = "Mainnet"
+    case testnet = "Testnet"
+    case stagenet = "Stagenet"
     
     static var current: Net {
-        #if MAINNET
+    #if MAINNET
         if UserDefaults.bool(forKey: "demomode.userdefaultskey".localized) == true {
             return .test
         }
-        return .main
-        #else
-        return .test
-        #endif
+        return .mainnet
+    #elseif TESTNET
+        return .testnet
+    #elseif STAGINGNET
+        return .stagenet
+    #endif
     }
 }


### PR DESCRIPTION
## Purpose

Fix `"environment":"prod_testnet"` mismatch during export account keys
Exported key from an account on Testnet contains "environment": "prod_testnet"

It should contain "environment": "testnet" for TESTNET and "environment": "mainnet" for MAINNET.

This way, keys will be consistent with keys exported by seed phrase Mobile wallets and Browser Wallet.

## Changes

Renamed associated values for `Environment` enum to match exports keys from rest of the platforms 

