### PR TITLE
Use optional "display" name for ID providers when present

### DIFF
--- a/ConcordiumWallet/Features/Identities/CreateIdentity/IdentityProviderList/IdentityProviderListPresenter.swift
+++ b/ConcordiumWallet/Features/Identities/CreateIdentity/IdentityProviderList/IdentityProviderListPresenter.swift
@@ -60,7 +60,7 @@ class IdentityProviderViewModel: IdentityGeneralViewModel {
 
     convenience init(ipInfo: IPInfoResponseElement) {
         let id = ipInfo.ipInfo.ipIdentity
-        let name = ipInfo.ipInfo.ipDescription.name
+        let name = ipInfo.displayName
         let encodedIcon = ipInfo.metadata.icon
         let url = ipInfo.ipInfo.ipDescription.url
 

--- a/ConcordiumWallet/Features/MoreSection/Export/ExportService.swift
+++ b/ConcordiumWallet/Features/MoreSection/Export/ExportService.swift
@@ -191,7 +191,8 @@ extension ExportIdentityData {
             support: identityProvider.support,
             issuanceStart: identityProvider.issuanceStartURL,
             recoveryStart: identityProvider.recoveryStartURL,
-            icon: identityProvider.icon
+            icon: identityProvider.icon,
+            display: identityProvider.ipInfo?.ipDescription.name
         )
       
         let identityProviderElm = IPInfoResponseElement(ipInfo: ipInfo, arsInfos: arsInfo, metadata: ipMetaData)

--- a/ConcordiumWallet/Features/NewOnboardingFlow/CreateIdentity/IdentityVerificationView.swift
+++ b/ConcordiumWallet/Features/NewOnboardingFlow/CreateIdentity/IdentityVerificationView.swift
@@ -218,7 +218,7 @@ struct IdentityVerificationView: View {
                 Image.init(base64String: provider.metadata.icon)?
                     .resizable()
                     .frame(width: 60, height: 60)
-                Text(provider.ipInfo.ipDescription.name)
+                Text(provider.displayName)
                     .font(.satoshi(size: 16, weight: .medium))
                     .foregroundStyle(Color.Neutral.tint1)
                     .multilineTextAlignment(.center)

--- a/ConcordiumWallet/Model/AutoGenerated/IPInfoResponseElement.swift
+++ b/ConcordiumWallet/Model/AutoGenerated/IPInfoResponseElement.swift
@@ -10,6 +10,10 @@ struct IPInfoResponseElement: Codable {
     let ipInfo: IPInfo
     let arsInfos: [String: ArsInfo]
     let metadata: Metadata
+    
+    var displayName: String {
+        metadata.display ?? ipInfo.ipDescription.name
+    }
 }
 
 // MARK: IPInfoResponseElement convenience initializers and mutators

--- a/ConcordiumWallet/Model/AutoGenerated/Metadata.swift
+++ b/ConcordiumWallet/Model/AutoGenerated/Metadata.swift
@@ -11,6 +11,7 @@ struct Metadata: Codable {
     let issuanceStart: String
     let recoveryStart: String?
     let icon: String
+    let display: String?
 }
 
 // MARK: Metadata convenience initializers and mutators
@@ -35,13 +36,15 @@ extension Metadata {
         support: String?? = nil,
         issuanceStart: String? = nil,
         recoveryStart: String? = nil,
-        icon: String? = nil
+        icon: String? = nil,
+        display: String? = nil
     ) -> Metadata {
         return Metadata(
             support: support ?? self.support,
             issuanceStart: issuanceStart ?? self.issuanceStart,
             recoveryStart: recoveryStart ?? self.recoveryStart,
-            icon: icon ?? self.icon
+            icon: icon ?? self.icon,
+            display: display ?? self.display
         )
     }
 


### PR DESCRIPTION
## Purpose

In the list of identity providers from the wallet proxy, the metadata might now contain a "display" field, which contains a string to display as the name of this Identity provider.
This name should be displayed if present, otherwise fallback to the name in ipDescription (current approach).
Related issue on the wallet proxy: https://github.com/Concordium/concordium-wallet-proxy/issues/102
