### PR TITLE
Fix crash on identity creation with CCD identity provider

### DIFF
--- a/ioscommon/Base/SwiftUI+Presenters.swift
+++ b/ioscommon/Base/SwiftUI+Presenters.swift
@@ -57,8 +57,9 @@ private class HostingController<ViewModel: PageModel & EventHandler, Content: Pa
         self.presenter = presenter
         
         super.init(rootView: page)
-        
-        setup()
+        if isViewLoaded {
+            setup()
+        }
     }
     
     private func setup() {


### PR DESCRIPTION
## Purpose

Fix crash on identity creation when user creating new identity with CCD identity provider.

## Changes

Added check if the view is already loaded to present alert after that, not while presenting view is in the process of loading.

https://github.com/user-attachments/assets/162dfbd1-c2e4-4818-8138-14277b619e3c
