### PR TITLE
Add correct link to video explainer

### DIFF
--- a/ioscommon/Base/AppConstants.swift
+++ b/ioscommon/Base/AppConstants.swift
@@ -10,7 +10,7 @@ struct AppConstants {
     }
     
     struct Media {
-        static let youtube = URL(string: "https://youtube.com/@ConcordiumNet?feature=shared")!
+        static let youtube = URL(string: "https://www.youtube.com/watch?v=eVZRuNWYs64")!
         static let ai = URL(string: "https://www.concordium.com/contact")!
     }
     


### PR DESCRIPTION
## Purpose

Add correct link to video explainer when user taps button 'Watch video' on the onboarding screen.

## Changes

Changes YouTube link.

https://github.com/user-attachments/assets/38dc72d9-d652-4e60-b03f-4dcfef414ffc

