### PR TITLE
fix naming of validator

### DIFF
--- a/ConcordiumWallet/Features/MoreSection/Export/ExportService.swift
+++ b/ConcordiumWallet/Features/MoreSection/Export/ExportService.swift
@@ -22,14 +22,14 @@ struct ExportService {
     
     private enum FileHandle {
         case backup
-        case bakerKeys
+        case validatorKeys
         
         var pathComponent: String {
             switch self {
             case .backup:
                 return "concordium-backup.concordiumwallet"
-            case .bakerKeys:
-                return "baker-credentials.json"
+            case .validatorKeys:
+                return "validator-credentials.json"
             }
         }
     }
@@ -67,12 +67,12 @@ struct ExportService {
     }
     
     func deleteBakerKeys() throws {
-        try FileManager.default.removeItem(at: urlForFile(.bakerKeys))
+        try FileManager.default.removeItem(at: urlForFile(.validatorKeys))
     }
     
     func export(bakerKeys: ExportedBakerKeys) throws -> URL {
         let keyData = try bakerKeys.jsonData()
-        let url = urlForFile(.bakerKeys)
+        let url = urlForFile(.validatorKeys)
         
         try keyData.write(to: url, options: .completeFileProtection)
         return url

--- a/ConcordiumWallet/Features/Stake/Delegation/PoolSelection/DelegationPoolSelectionViewController.swift
+++ b/ConcordiumWallet/Features/Stake/Delegation/PoolSelection/DelegationPoolSelectionViewController.swift
@@ -66,7 +66,7 @@ class DelegationPoolSelectionViewController: KeyboardDismissableBaseViewControll
         
         UILabel.appearance(whenContainedInInstancesOf: [UISegmentedControl.self]).numberOfLines = 0
         poolSelectionSegmentedControl.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.black], for: .selected)
-        poolSelectionSegmentedControl.setTitle("delegation.pool.baker".localized, forSegmentAt: 0)
+        poolSelectionSegmentedControl.setTitle("delegation.pool.validator".localized, forSegmentAt: 0)
         poolSelectionSegmentedControl.setTitle("delegation.pool.passive".localized, forSegmentAt: 1)
         linkListener = bottomLabel.addOnLinkPressedListener()
         

--- a/ConcordiumWallet/Resources/en.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/en.lproj/Localizable.strings
@@ -769,11 +769,11 @@ If you don’t have enough CCD at disposal on your balance, you might not be abl
 For more info you can visit
 developer.concordium.software";
 
-"delegation.pool.baker" = "Baker";
+"delegation.pool.validator" = "Validator";
 "delegation.pool.passive" = "Passive";
-"delegation.pool.idplaceholder.create" = "Enter baker pool ID";
-"delegation.pool.idplaceholder.update" = "Optional: New baker pool ID";
-"delegation.pool.invalidbakerid" = "Invalid target baker pool ID";
+"delegation.pool.idplaceholder.create" = "Enter validator pool ID";
+"delegation.pool.idplaceholder.update" = "Optional: New validator pool ID";
+"delegation.pool.invalidbakerid" = "Invalid target validator pool ID";
 "delegation.pool.closedpool" = "This pool is closed";
 
 "delegation.pool.sizewarning.title" = "Current delegation amount too large";


### PR DESCRIPTION
## Purpose

Rename 'baker' to 'validator' when setting up and rename file with validator keys when saving.