### PR TITLE
Fix looping when identity request gets failed

### DIFF
--- a/ConcordiumWallet/AppCoordinator.swift
+++ b/ConcordiumWallet/AppCoordinator.swift
@@ -94,7 +94,7 @@ class AppCoordinator: NSObject, Coordinator, ShowAlert, RequestPasswordDelegate 
     private func onboardingDone() {
         defaultProvider.storageManager().removeAccountsWithoutAddress()
         
-        let identities = defaultProvider.storageManager().getIdentities()
+        let identities = defaultProvider.storageManager().getIdentities().filter({$0.identityCreationError.isEmpty})
         let accounts = defaultProvider.storageManager().getAccounts()
         
         if !accounts.isEmpty || !identities.isEmpty {
@@ -150,7 +150,7 @@ class AppCoordinator: NSObject, Coordinator, ShowAlert, RequestPasswordDelegate 
     
 
     private func showLogin() {
-        let identities = defaultProvider.storageManager().getIdentities()
+        let identities = defaultProvider.storageManager().getIdentities().filter({$0.identityCreationError.isEmpty})
         let accounts = defaultProvider.storageManager().getAccounts()
         
         navigationController.popViewController(animated: false)

--- a/ConcordiumWallet/Features/NewOnboardingFlow/CreateIdentity/NewIdentityStatusView.swift
+++ b/ConcordiumWallet/Features/NewOnboardingFlow/CreateIdentity/NewIdentityStatusView.swift
@@ -132,6 +132,7 @@ final class NewIdentityStatusViewModel: ObservableObject {
 struct NewIdentityStatusView: View {
     @StateObject var viewModel: NewIdentityStatusViewModel
     var onIdentityCreated: () -> Void
+    var onIdentityCreationFailed: () -> Void
     
     var body: some View {
         ZStack {
@@ -151,6 +152,24 @@ struct NewIdentityStatusView: View {
                     }, label: {
                         HStack {
                             Text("create_account_btn_title".localized)
+                                .font(Font.satoshi(size: 16, weight: .medium))
+                                .lineSpacing(24)
+                                .foregroundColor(Color.Neutral.tint7)
+                            Spacer()
+                            Image(systemName: "arrow.right").tint(Color.Neutral.tint7)
+                        }
+                        .padding(.horizontal, 24)
+                    })
+                    .frame(height: 56)
+                    .background(Color.EggShell.tint1)
+                    .cornerRadius(28, corners: .allCorners)
+                    .padding(16)
+                } else if viewModel.state == .rejected {
+                    Button(action: {
+                        self.onIdentityCreationFailed()
+                    }, label: {
+                        HStack {
+                            Text("identityStatus.failed".localized + ". " + "identityfailed.tryagain".localized)
                                 .font(Font.satoshi(size: 16, weight: .medium))
                                 .lineSpacing(24)
                                 .foregroundColor(Color.Neutral.tint7)


### PR DESCRIPTION
## Purpose

Fix issue when identity request is failed user gets stuck in a loop.

## Changes

- return to the 'selectIdentityProvider' state when create identity request failed.
- fix issue, when identity request failed and user has no confirmed identities,  kills app and reopen, app shows main accounts screen and proposes to create account.
