### PR TITLE
pre-set the address and the token

### DIFF
--- a/ConcordiumWallet/Features/OnrampFlow/CCDOnrampView.swift
+++ b/ConcordiumWallet/Features/OnrampFlow/CCDOnrampView.swift
@@ -46,7 +46,8 @@ struct CCDOnrampView: View {
                                             isAccountsPickerShown = provider
                                         } else {
                                             UIPasteboard.general.string = accounts.first?.address
-                                            openURL(provider.url)
+                                            let url = provider.title == "Swipelux" ? CCDOnrampViewDataProvider.generateSwipeluxURL(baseURL: provider.url, targetAddress: accounts.first?.address) : provider.url
+                                            openURL(url)
                                         }
                                     }
                             }

--- a/ConcordiumWallet/Features/OnrampFlow/CCDOnrampViewDataProvider.swift
+++ b/ConcordiumWallet/Features/OnrampFlow/CCDOnrampViewDataProvider.swift
@@ -47,7 +47,7 @@ final class CCDOnrampViewDataProvider {
         [
             DataProvider(
                 title: "Swipelux",
-                url: URL(string: "https://swipelux.com/buy_ccd")!,
+                url: URL(string: "https://track.swipelux.com?api-key=\(AppConstants.apiKey)")!,
                 icon: URL(string: "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/65e825be9290e43f9d1bc29b_52c3517d-1bb0-4705-a952-8f0d2746b4c5.jpg")!,
                 isPaymentProvider: true
             ),
@@ -134,4 +134,34 @@ final class CCDOnrampViewDataProvider {
             )
         #endif
     }
+    
+    static func generateSwipeluxURL(
+        baseURL: URL,
+        targetAddress: String? = nil,
+        phone: String? = nil,
+        email: String? = nil,
+        fiatAmount: Double? = nil
+    ) -> URL {
+        var urlComponents = URLComponents(string: baseURL.absoluteString)
+        
+        var queryItems: [URLQueryItem] = []
+        
+        if let targetAddress = targetAddress {
+            queryItems.append(URLQueryItem(name: "targetAddress", value: targetAddress))
+        }
+        if let phone = phone {
+            queryItems.append(URLQueryItem(name: "phone", value: phone))
+        }
+        if let email = email {
+            queryItems.append(URLQueryItem(name: "email", value: email))
+        }
+        if let fiatAmount = fiatAmount {
+            queryItems.append(URLQueryItem(name: "fiatAmount", value: "\(fiatAmount)"))
+        }
+        
+        urlComponents?.queryItems?.append(contentsOf: queryItems)
+        
+        return urlComponents?.url ?? baseURL
+    }
+
 }

--- a/ConcordiumWallet/Features/OnrampFlow/OnrampAccountPicker.swift
+++ b/ConcordiumWallet/Features/OnrampFlow/OnrampAccountPicker.swift
@@ -24,8 +24,9 @@ struct OnrampAccountPicker: View {
             
             ForEach(accountModels) { account in
                 Button(action: {
+                    let url = provider.title == "Swipelux" ? CCDOnrampViewDataProvider.generateSwipeluxURL(baseURL: provider.url, targetAddress: account.address) : provider.url
                     UIPasteboard.general.string = account.address
-                    openURL(provider.url)
+                    openURL(url)
                     dismiss()
                 }, label: {
                     AccountView(account)

--- a/ioscommon/Base/AppConstants.swift
+++ b/ioscommon/Base/AppConstants.swift
@@ -20,6 +20,7 @@ struct AppConstants {
     }
     
     static let rssFeedURL = URL(string: "https://concordium-new.webflow.io/cryptox-news-articles/rss.xml")!
+    static let apiKey = "6515da6d-a065-4676-a214-c83e5b18f5f3"
     
     struct MatomoTracker {
         static let baseUrl: String = "https://concordium.matomo.cloud/matomo.php"


### PR DESCRIPTION
## Purpose

Use the new customizable page allowing pre-setting the address and the token for Swipelux.

## Changes

- add api key for presetting CCD token
- pre-set the selected account address via the UR
