### PR TITLE
Change scalability of the preview image in news tab

### DIFF
--- a/ConcordiumWallet/Features/NewsFeed/NewsFeed.swift
+++ b/ConcordiumWallet/Features/NewsFeed/NewsFeed.swift
@@ -103,7 +103,7 @@ struct NewsFeed: View {
         .cornerRadius(10)
         .shadow(radius: 5)
         .frame(width: size.width - 64)
-        .frame(height: size.width * 0.6)
+        .frame(height: size.width * 0.4)
         .clipped()
     }
 }


### PR DESCRIPTION
## Purpose

Change scalability of the preview image in news tab
![image](https://github.com/user-attachments/assets/62c54d3e-f905-4402-956d-6c04c0e359d9)

