### PR TITLE
fix onboarding for wallet imported from files

### DIFF
--- a/ConcordiumWallet/AppCoordinator.swift
+++ b/ConcordiumWallet/AppCoordinator.swift
@@ -47,6 +47,7 @@ class AppCoordinator: NSObject, Coordinator, ShowAlert, RequestPasswordDelegate 
     
     @AppStorage("isRestoredDefaultCIS2Tokens") private var isRestoredDefaultCIS2Tokens = false
     @AppStorage("isAcceptedPrivacy") private var isAcceptedPrivacy = false
+    @AppStorage("isImportedFromFile") private var isImportedFromFile = false
     
     ///
     /// Well, this is was done because of keychain migration issue,  we can remove this after some migration
@@ -539,6 +540,7 @@ extension AppCoordinator: MoreCoordinatorDelegate {
         clearAppDataFromPreviousInstall()
         accountsCoordinator?.childCoordinators.removeAll()
         accountsCoordinator = nil
+        isImportedFromFile = false
         childCoordinators.removeAll()
         navigationController = CXNavigationController()
         UIApplication.shared.windows.filter {$0.isKeyWindow}.first?.rootViewController = navigationController

--- a/ConcordiumWallet/Features/AccountsMainView/ViewModels/AccountsMainViewModel.swift
+++ b/ConcordiumWallet/Features/AccountsMainView/ViewModels/AccountsMainViewModel.swift
@@ -75,7 +75,7 @@ final class AccountsMainViewModel: ObservableObject {
     
     private func updateData() {
         accountViewModels = accounts.map { AccountPreviewViewModel.init(account: $0, tokens: dependencyProvider.storageManager().getAccountSavedCIS2Tokens($0.address)) }
-        if defaultProvider.mobileWallet().isLegacyAccount() {
+        if defaultProvider.mobileWallet().isLegacyAccount() && AppSettings.isImportedFromFile {
             state = .accounts
         } else {
             withAnimation {

--- a/ConcordiumWallet/Features/MoreSection/Export/ImportCoordinator.swift
+++ b/ConcordiumWallet/Features/MoreSection/Export/ImportCoordinator.swift
@@ -77,6 +77,7 @@ class ImportCoordinator: Coordinator {
                 receiveValue: { [weak self] (importedItemsReport: ImportedItemsReport?) in
                     guard let self = self, let importedItemsReport = importedItemsReport else { return }
                     self.showImportReceipt(report: importedItemsReport)
+                    AppSettings.isImportedFromFile = true
             })
             .store(in: &cancellables)
     }

--- a/ConcordiumWallet/Settings/AppSettings.swift
+++ b/ConcordiumWallet/Settings/AppSettings.swift
@@ -33,6 +33,7 @@ enum UserDefaultKeys: String {
     case dismissedAlertIds
     
     case hasRunBefore
+    case isImportedFromFile
 }
 
 struct AppSettings {
@@ -161,6 +162,15 @@ extension AppSettings {
         }
         set {
             UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.hasRunBefore.rawValue)
+        }
+    }
+    
+    static var isImportedFromFile: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: UserDefaultKeys.isImportedFromFile.rawValue)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.isImportedFromFile.rawValue)
         }
     }
 }


### PR DESCRIPTION
## Purpose

Add property to mark if the wallet is imported from file. Property `isLegacyAccount` doesn't work properly, because it defines only if the seed phrase was saved.
