### PR TITLE
fix amount formatting on the send screen

### DIFF
--- a/ConcordiumWallet/Features/AccountDetail/TokenFormatter.swift
+++ b/ConcordiumWallet/Features/AccountDetail/TokenFormatter.swift
@@ -212,7 +212,7 @@ public class TokenFormatter {
         fractional = fractional.removingTrailingZeroes
 
         let integerGroupped = Self.groups(string: integer, size: 3).joined(separator: thousandSeparator)
-        let magnitude = fractional.isEmpty ? integerGroupped : integerGroupped + decimalSeparator + fractional
+        let magnitude = fractional.isEmpty ? integerGroupped + decimalSeparator + "00" : integerGroupped + decimalSeparator + fractional
         let sign = magnitude != "0" ? (isNegative ? negativeSign : positiveSign) : ""
 
         if magnitude == "0" {
@@ -235,7 +235,7 @@ public class TokenFormatter {
         let integer = String(numberString.prefix(numberString.count - fractional.count))
         fractional = fractional.removingTrailingZeroes
         
-        let integerGroupped = Self.groups(string: integer, size: 3).joined(separator: "")
+        let integerGroupped = Self.groups(string: integer, size: 3).joined(separator: ",")
 
         
         return fractional.isEmpty ? integerGroupped : integerGroupped + decimalSeparator + fractional

--- a/ConcordiumWallet/Features/TransferTokenFlow/Models/TransferTokenViewModel.swift
+++ b/ConcordiumWallet/Features/TransferTokenFlow/Models/TransferTokenViewModel.swift
@@ -160,12 +160,12 @@ final class TransferTokenViewModel: ObservableObject {
         
         
         tokenTransferModel.$tokenGeneralBalance
-            .map { TokenFormatter().string(from: $0) }
+            .map { TokenFormatter().string(from: $0, decimalSeparator: ".", thousandSeparator: ",") }
             .assign(to: \.availableDisplayAmount, on: self)
             .store(in: &cancellables)
         
         tokenTransferModel.$ccdTokenDisposalBalance
-            .map { TokenFormatter().string(from: $0) }
+            .map { TokenFormatter().string(from: $0, decimalSeparator: ".", thousandSeparator: ",") }
             .assign(to: \.atDisposalCCDDisplayAmount, on: self)
             .store(in: &cancellables)
         


### PR DESCRIPTION
## Purpose

Format entered amount the same as on other screens.

## Changes

- Removed code duplication.
- Used hardcoded thousand grouping and decimal separators.
- Changed the placeholder value.
- Limited the maximum number of fractional digits the user can enter to the value passed during initialization.


https://github.com/user-attachments/assets/78dc1f84-c35a-4dda-8c55-bd90e1a928c7

