### PR TITLE
fix crash when recovering using private key

### DIFF
--- a/ConcordiumWallet/Design/SwiftUI/KeyboardAvoidingPadding.swift
+++ b/ConcordiumWallet/Design/SwiftUI/KeyboardAvoidingPadding.swift
@@ -1,0 +1,33 @@
+//
+//  KeyboardAvoidingPadding.swift
+//  CryptoX
+//
+//  Created by Zhanna Komar on 07.03.2025.
+//  Copyright © 2025 pioneeringtechventures. All rights reserved.
+//
+
+import SwiftUI
+import Combine
+
+struct KeyboardAvoidingPadding: ViewModifier {
+    @State private var keyboardHeight: CGFloat = 0
+    private var publisher: AnyPublisher<CGFloat, Never> {
+        Publishers.Merge(
+            NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
+                .compactMap { ($0.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect)?.height },
+            NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
+                .map { _ in CGFloat(0) }
+        )
+        .eraseToAnyPublisher()
+    }
+    
+    func body(content: Content) -> some View {
+        content
+            .padding(.bottom, keyboardHeight)
+            .onReceive(publisher) { height in
+                withAnimation {
+                    keyboardHeight = height
+                }
+            }
+    }
+}

--- a/ConcordiumWallet/Features/NewOnboardingFlow/ImportSeedBasedWallet/ViewModels/ImportWalletPrivateKeyViewModel.swift
+++ b/ConcordiumWallet/Features/NewOnboardingFlow/ImportSeedBasedWallet/ViewModels/ImportWalletPrivateKeyViewModel.swift
@@ -37,9 +37,14 @@ final class ImportWalletPrivateKeyViewModel: ObservableObject {
             if validateWalletPrivateKey() {
                 walletPrivateKey = IdentifiableString(value: currentInput)
                 isValidPhrase = true
-                error = nil
+                withAnimation {
+                    error = nil
+                }
             } else {
-                error = "recoveryphrase.recover.input.validationerror".localized
+                withAnimation {
+                    isValidPhrase = false
+                    error = "recoveryphrase.recover.input.validationerror".localized
+                }
             }
         }
     }
@@ -71,18 +76,24 @@ final class ImportWalletPrivateKeyViewModel: ObservableObject {
 
     
     private func hexStringToByteArray(_ hex: String) throws -> [UInt8] {
+        guard hex.count % 2 == 0 else {
+            throw NSError(domain: "Invalid hex string: length must be even", code: 0, userInfo: nil)
+        }
+
         var bytes = [UInt8]()
         var index = hex.startIndex
         while index < hex.endIndex {
-            let byteString = String(hex[index..<hex.index(index, offsetBy: 2)])
+            let nextIndex = hex.index(index, offsetBy: 2)
+            let byteString = String(hex[index..<nextIndex])
+            
             if let byte = UInt8(byteString, radix: 16) {
                 bytes.append(byte)
             } else {
                 throw NSError(domain: "Invalid hex string", code: 0, userInfo: nil)
             }
-            index = hex.index(index, offsetBy: 2)
+            
+            index = nextIndex
         }
         return bytes
     }
-
 }

--- a/CryptoX.xcodeproj/project.pbxproj
+++ b/CryptoX.xcodeproj/project.pbxproj
@@ -1851,6 +1851,9 @@
 		1558E8992CFA2BB500004E71 /* DotLottie in Frameworks */ = {isa = PBXBuildFile; productRef = 1558E8982CFA2BB500004E71 /* DotLottie */; };
 		1558E89B2CFA2BBF00004E71 /* DotLottie in Frameworks */ = {isa = PBXBuildFile; productRef = 1558E89A2CFA2BBF00004E71 /* DotLottie */; };
 		1558E89D2CFA2BC700004E71 /* DotLottie in Frameworks */ = {isa = PBXBuildFile; productRef = 1558E89C2CFA2BC700004E71 /* DotLottie */; };
+		155EE23D2D7B4955005EF86E /* KeyboardAvoidingPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155EE23C2D7B4955005EF86E /* KeyboardAvoidingPadding.swift */; };
+		155EE23E2D7B4955005EF86E /* KeyboardAvoidingPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155EE23C2D7B4955005EF86E /* KeyboardAvoidingPadding.swift */; };
+		155EE23F2D7B4955005EF86E /* KeyboardAvoidingPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155EE23C2D7B4955005EF86E /* KeyboardAvoidingPadding.swift */; };
 		156878D22CD0FC190080B2F3 /* confettiAnimation.json in Resources */ = {isa = PBXBuildFile; fileRef = 156878D12CD0FC190080B2F3 /* confettiAnimation.json */; };
 		156878D32CD0FC190080B2F3 /* confettiAnimation.json in Resources */ = {isa = PBXBuildFile; fileRef = 156878D12CD0FC190080B2F3 /* confettiAnimation.json */; };
 		156878D42CD0FC190080B2F3 /* confettiAnimation.json in Resources */ = {isa = PBXBuildFile; fileRef = 156878D12CD0FC190080B2F3 /* confettiAnimation.json */; };
@@ -3230,6 +3233,7 @@
 		1557CC972C89BBD7008ABF67 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		1557CC9A2C89BE26008ABF67 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		1557CCA82C8AF779008ABF67 /* AllowNotificationsPopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllowNotificationsPopup.swift; sourceTree = "<group>"; };
+		155EE23C2D7B4955005EF86E /* KeyboardAvoidingPadding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardAvoidingPadding.swift; sourceTree = "<group>"; };
 		156878D12CD0FC190080B2F3 /* confettiAnimation.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = confettiAnimation.json; sourceTree = "<group>"; };
 		1575862D2CA2CA4D00205A6E /* IdentifiableString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableString.swift; sourceTree = "<group>"; };
 		157586312CA43E5500205A6E /* CooldownEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CooldownEntity.swift; sourceTree = "<group>"; };
@@ -4129,6 +4133,7 @@
 				15EFE9F82C74CD4700B7145C /* CustomSearchBar.swift */,
 				1580EBD82D4919C30051C55D /* SliderButton.swift */,
 				152AE63B2D50E17700B0B073 /* PrsssedButtonStyle.swift */,
+				155EE23C2D7B4955005EF86E /* KeyboardAvoidingPadding.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -7440,6 +7445,7 @@
 				08C167EB2BB7396200E61326 /* Features.swift in Sources */,
 				08C167ED2BB7396200E61326 /* RecoveryPhraseRecoverCompleteViewModel.swift in Sources */,
 				08C167EF2BB7396200E61326 /* IdentityAttributeEntity.swift in Sources */,
+				155EE23D2D7B4955005EF86E /* KeyboardAvoidingPadding.swift in Sources */,
 				08C167F02BB7396200E61326 /* IdentityDataSelectionCell.swift in Sources */,
 				08C167F12BB7396200E61326 /* SessionProposalView.swift in Sources */,
 				08C167F22BB7396200E61326 /* IdentityCell.swift in Sources */,
@@ -8156,6 +8162,7 @@
 				088FF16F2A0292DB00042957 /* Features.swift in Sources */,
 				088FF0B52A02845C00042957 /* RecoveryPhraseRecoverCompleteViewModel.swift in Sources */,
 				D589F1A92794B5ED003F2FBB /* IdentityAttributeEntity.swift in Sources */,
+				155EE23F2D7B4955005EF86E /* KeyboardAvoidingPadding.swift in Sources */,
 				7F85B863246A9AB600ED09B8 /* IdentityDataSelectionCell.swift in Sources */,
 				089B34212A16845600F3CD90 /* SessionProposalView.swift in Sources */,
 				7F85B865246A9AB600ED09B8 /* IdentityCell.swift in Sources */,
@@ -8872,6 +8879,7 @@
 				088FF16D2A0292DB00042957 /* Features.swift in Sources */,
 				089B341F2A16845600F3CD90 /* SessionProposalView.swift in Sources */,
 				D589F1A72794B5ED003F2FBB /* IdentityAttributeEntity.swift in Sources */,
+				155EE23E2D7B4955005EF86E /* KeyboardAvoidingPadding.swift in Sources */,
 				088FF0B12A02845B00042957 /* RecoveryPhraseRecoverCompleteViewModel.swift in Sources */,
 				C9D342B9245884AA007ED45E /* ShowErrorProtocol.swift in Sources */,
 				C95CE0C02439EDC500B1A88D /* AccountDetailsIdentityDataCellView.swift in Sources */,


### PR DESCRIPTION
## Purpose

fix crash when recovering using private key

## Changes

- fix UI of the Export using private key view
- when user pasted key with some empty line (\n) the code assumes that hex always has an even number of characters, but if it has an odd length(empty line), `hex.index(index, offsetBy: 2)` went beyond the string’s bounds.
