### PR TITLE
Add suspended account indicator on the account switch

### DIFF
--- a/ConcordiumWallet/Features/AccountsMainView/ViewModels/AccountsMainViewModel.swift
+++ b/ConcordiumWallet/Features/AccountsMainView/ViewModels/AccountsMainViewModel.swift
@@ -90,6 +90,18 @@ final class AccountsMainViewModel: ObservableObject, Hashable, Equatable {
         }
     }
     
+    func hasSuspendedAccounts() -> Bool {
+        for acc in accounts {
+            if (acc.baker?.isSuspended ?? false) ||
+               (acc.delegation?.isSuspended ?? false) ||
+               (acc.baker?.isPrimedForSuspension ?? false) ||
+               (acc.delegation?.isPrimedForSuspension ?? false) {
+                return true
+            }
+        }
+        return false
+    }
+    
     private func updateData() {
         accountViewModels = accounts.map { AccountPreviewViewModel.init(account: $0, tokens: dependencyProvider.storageManager().getAccountSavedCIS2Tokens($0.address)) }
         updateDotImageNames()

--- a/ConcordiumWallet/Features/AccountsMainView/ViewModels/AccountsMainViewModel.swift
+++ b/ConcordiumWallet/Features/AccountsMainView/ViewModels/AccountsMainViewModel.swift
@@ -89,17 +89,32 @@ final class AccountsMainViewModel: ObservableObject, Hashable, Equatable {
             debugPrint(error)
         }
     }
-    
-    func hasSuspendedAccounts() -> Bool {
-        for acc in accounts {
-            if (acc.baker?.isSuspended ?? false) ||
-               (acc.delegation?.isSuspended ?? false) ||
-               (acc.baker?.isPrimedForSuspension ?? false) ||
-               (acc.delegation?.isPrimedForSuspension ?? false) {
-                return true
-            }
+
+    func suspendedOrPrimedAccounts() -> [AccountEntity] {
+        var result: [AccountEntity] = []
+
+        if let selected = selectedAccount?.account,
+           selected.baker?.isSuspended == true ||
+           selected.delegation?.isSuspended == true ||
+           selected.baker?.isPrimedForSuspension == true ||
+           selected.delegation?.isPrimedForSuspension == true {
+            result.append(selected)
         }
-        return false
+
+        let others = accountViewModels.compactMap { vm -> AccountEntity? in
+            guard let acc = vm.account else { return nil }
+            let isSuspended = acc.baker?.isSuspended == true || acc.delegation?.isSuspended == true
+            let isPrimed = acc.baker?.isPrimedForSuspension == true || acc.delegation?.isPrimedForSuspension == true
+
+            // Avoid adding the selected account twice
+            if (isSuspended || isPrimed), acc.address != selectedAccount?.account?.address {
+                return acc
+            }
+            return nil
+        }
+
+        result.append(contentsOf: others)
+        return result
     }
     
     private func updateData() {
@@ -136,8 +151,9 @@ final class AccountsMainViewModel: ObservableObject, Hashable, Equatable {
         try await dependencyProvider.accountsService().updateAccountsBalances(accounts: accounts).async()
     }
     
-    func changeCurrentAccount(_ account: AccountPreviewViewModel) {
-        selectedAccount = account
+    func changeCurrentAccount(_ account: AccountEntity?) {
+        let accountPreviewViewModel = accountViewModels.first(where: {$0.address == account?.address})
+        selectedAccount = accountPreviewViewModel
     }
 }
 

--- a/ConcordiumWallet/Features/NewAccountFlow/AccountsOverviewView.swift
+++ b/ConcordiumWallet/Features/NewAccountFlow/AccountsOverviewView.swift
@@ -27,7 +27,7 @@ struct AccountsOverviewView: View {
                         selectedAccountAddress = account.address
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                             selectedAccountAddress = nil
-                            viewModel.changeCurrentAccount(account)
+                            viewModel.changeCurrentAccount(account.account)
                             dismiss()
                         }
                     } label: {

--- a/ConcordiumWallet/Features/NewAccountFlow/HomeScreen/HomeScreenView.swift
+++ b/ConcordiumWallet/Features/NewAccountFlow/HomeScreen/HomeScreenView.swift
@@ -131,13 +131,6 @@ struct HomeScreenView: View {
                         .onTapGesture {
                             navigationManager.navigate(to: .accountsOverview(viewModel))
                         }
-                        .overlay(alignment: .topLeading) {
-                            if viewModel.hasSuspendedAccounts() {
-                                Circle().fill(.attentionRed)
-                                    .frame(width: 8, height: 8)
-                                    .offset(x: -8, y: -8)
-                            }
-                        }
                     }
                 }
                 ToolbarItem(placement: .topBarTrailing) {
@@ -181,22 +174,34 @@ struct HomeScreenView: View {
                         self.router?.showExportFlow()
                     }
                 }
-                
-                if viewModel.selectedAccount?.account?.baker?.isSuspended == true || viewModel.selectedAccount?.account?.delegation?.isSuspended == true {
+
+                let suspendedAccounts = viewModel.suspendedOrPrimedAccounts()
+
+                if suspendedAccounts.count > 1 {
                     Button {
-                        if let selectedAccount = viewModel.selectedAccount?.account as? AccountEntity {
-                            navigationManager.navigate(to: .earn(selectedAccount))
-                        }
+                        navigationManager.navigate(to: .accountsOverview(viewModel))
                     } label: {
-                        StakerSuspensionStateView(type: .suspended, stakeType: viewModel.selectedAccount?.account?.baker?.isSuspended == true ? .baker : .delegation)
+                        StakerSuspensionStateView(message: "multiple.accounts.suspended".localized, type: nil, stakeType: nil)
                     }
-                } else if viewModel.selectedAccount?.account?.baker?.isPrimedForSuspension == true || viewModel.selectedAccount?.account?.delegation?.isPrimedForSuspension == true {
-                    Button {
-                        if let selectedAccount = viewModel.selectedAccount?.account as? AccountEntity {
-                            navigationManager.navigate(to: .earn(selectedAccount))
+                } else if let account = suspendedAccounts.first {
+                    let isSuspended = account.baker?.isSuspended == true || account.delegation?.isSuspended == true
+                    let isPrimed = account.baker?.isPrimedForSuspension == true || account.delegation?.isPrimedForSuspension == true
+
+                    let suspensionType: StakerSuspensionStateView.StakerSuspensionState? =
+                        isSuspended ? .suspended : (isPrimed ? .primedForSuspension : nil)
+
+                    let stakeType: StakerSuspensionStateView.StakerType? =
+                        account.baker?.isSuspended == true || account.baker?.isPrimedForSuspension == true ? .baker : .delegation
+
+                    if let type = suspensionType, let stake = stakeType {
+                        Button {
+                            if account.address != viewModel.selectedAccount?.account?.address {
+                                viewModel.changeCurrentAccount(account)
+                            }
+                            navigationManager.navigate(to: .earn(account))
+                        } label: {
+                            StakerSuspensionStateView(message: nil, type: type, stakeType: stake)
                         }
-                    } label: {
-                        StakerSuspensionStateView(type: .primedForSuspension, stakeType: viewModel.selectedAccount?.account?.baker?.isPrimedForSuspension == true ? .baker : .delegation)
                     }
                 }
                 
@@ -575,7 +580,6 @@ struct StakerSuspensionStateView: View {
     enum StakerSuspensionState {
         case suspended, primedForSuspension
         
-        
         func title(for type: StakerType) -> String {
             switch (self, type) {
             case (.suspended, .baker):
@@ -595,14 +599,24 @@ struct StakerSuspensionStateView: View {
         case delegation
     }
     
-    let type: StakerSuspensionState
-    let stakeType: StakerType
+    let message: String?
+    let type: StakerSuspensionState?
+    let stakeType: StakerType?
+    
     var body: some View {
         HStack(spacing: 16) {
             Image("Pause")
-            Text(type.title(for: stakeType))
-                .font(.satoshi(size: 12, weight: .regular))
-                .foregroundStyle(Color.white)
+            
+            if let message = message {
+                Text(message)
+                    .font(.satoshi(size: 12, weight: .regular))
+                    .foregroundStyle(Color.white)
+            } else if let type = type, let stakeType = stakeType {
+                Text(type.title(for: stakeType))
+                    .font(.satoshi(size: 12, weight: .regular))
+                    .foregroundStyle(Color.white)
+            }
+            
             Spacer(minLength: 0)
             Image("ArrowUp")
         }

--- a/ConcordiumWallet/Features/NewAccountFlow/HomeScreen/HomeScreenView.swift
+++ b/ConcordiumWallet/Features/NewAccountFlow/HomeScreen/HomeScreenView.swift
@@ -131,6 +131,13 @@ struct HomeScreenView: View {
                         .onTapGesture {
                             navigationManager.navigate(to: .accountsOverview(viewModel))
                         }
+                        .overlay(alignment: .topLeading) {
+                            if viewModel.hasSuspendedAccounts() {
+                                Circle().fill(.attentionRed)
+                                    .frame(width: 8, height: 8)
+                                    .offset(x: -8, y: -8)
+                            }
+                        }
                     }
                 }
                 ToolbarItem(placement: .topBarTrailing) {

--- a/ConcordiumWallet/Resources/en.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/en.lproj/Localizable.strings
@@ -1466,3 +1466,6 @@ Remember to restart your node with the validator keys.";
 "allow.tracking.title" = "Help Us Improve Your Experience";
 "allow.tracking.msg" = "Please enable tracking in Settings to help us provide better personalized experiences.";
 "go.to.settings" = "Go to settings";
+"primed.for.suspension.message" = "Your validation is primed for suspension";
+"suspended.message" =  "Your validation has been suspended";
+"multiple.accounts.suspended" = "Validation issues with several accounts";


### PR DESCRIPTION
## Changes

- Add suspended account banner to support case when multiple account are suspended or primed for suspension.
- Apply this banner to all accounts, not only to one with the problem.
- 
<img src="https://github.com/user-attachments/assets/8b058d7f-597d-4a92-8eb4-f53a1512c193" width="300">

