### PR TITLE
Store seed phrase backup file on iCloud Drive

### DIFF
--- a/ConcordiumWallet/AppCoordinator.swift
+++ b/ConcordiumWallet/AppCoordinator.swift
@@ -533,6 +533,7 @@ extension AppCoordinator: MoreCoordinatorDelegate {
         AppSettings.removeImportedWalletSetings()
         navigationController = CXNavigationController()
         UserDefaults.standard.set(false, forKey: "showConfettiAnimation")
+        UserDefaults.removeObject(forKey: UserDefaultKeys.isOnboardingFinished.rawValue)
         UIApplication.shared.windows.filter {$0.isKeyWindow}.first?.rootViewController = navigationController
         start()
     }

--- a/ConcordiumWallet/Features/AccountsMainView/ViewModels/AccountsMainViewModel.swift
+++ b/ConcordiumWallet/Features/AccountsMainView/ViewModels/AccountsMainViewModel.swift
@@ -122,6 +122,7 @@ final class AccountsMainViewModel: ObservableObject, Hashable, Equatable {
         updateDotImageNames()
         if defaultProvider.mobileWallet().isLegacyAccount() && AppSettings.isImportedFromFile {
             state = .accounts
+            AppSettings.isOnboardingFinished = true
         } else {
             withAnimation {
                 if !defaultProvider.seedMobileWallet().hasSetupRecoveryPhrase {
@@ -136,6 +137,7 @@ final class AccountsMainViewModel: ObservableObject, Hashable, Equatable {
                     state = .createAccount
                 } else {
                     state = .accounts
+                    AppSettings.isOnboardingFinished = true
                 }
             }
         }

--- a/ConcordiumWallet/Features/NewOnboardingFlow/ImportSeedBasedWallet/ImportWalletView.swift
+++ b/ConcordiumWallet/Features/NewOnboardingFlow/ImportSeedBasedWallet/ImportWalletView.swift
@@ -57,8 +57,8 @@ struct ImportWalletView: View {
                         selection: $flow) { EmptyView() }
 
                     NavigationLink(
-                        destination: ImportSeedPhraseBackupFileView(viewModel: BackupFileViewModel.init(recoveryService: defaultProvider.recoveryPhraseService(), onValidPhrase: { key in
-                            self.walletPrivateKey = key
+                        destination: ImportSeedPhraseBackupFileView(viewModel: BackupFileViewModel.init(recoveryService: defaultProvider.recoveryPhraseService(), onValidPhrase: { phrase in
+                            self.recoveryPhrase = phrase
                         })),
                         tag: Flow.recoverwithSeedPhraseBackup,
                         selection: $flow) { EmptyView() }
@@ -149,6 +149,19 @@ struct ImportWalletView: View {
             }
             .onTapGesture {
                 self.flow = .recoverWithWalletKey
+            }
+            
+            Divider()
+                .tint(Color("black_secondary"))
+            
+            HStack {
+                Text("Import via iCloud backup")
+                    .font(.satoshi(size: 14, weight: .regular))
+                Spacer()
+                Image(systemName: "arrow.right").tint(Color.Neutral.tint1)
+            }
+            .onTapGesture {
+                self.flow = .recoverwithSeedPhraseBackup
             }
         }
         .frame(maxWidth: .infinity)

--- a/ConcordiumWallet/Features/NewOnboardingFlow/ImportSeedBasedWallet/ImportWalletView.swift
+++ b/ConcordiumWallet/Features/NewOnboardingFlow/ImportSeedBasedWallet/ImportWalletView.swift
@@ -19,6 +19,7 @@ struct ImportWalletView: View {
     enum Flow {
         case recoverPhraseInput
         case recoverWithWalletKey
+        case recoverwithSeedPhraseBackup
     }
     
     @State private var flow: Flow? = nil
@@ -54,7 +55,14 @@ struct ImportWalletView: View {
                         })),
                         tag: Flow.recoverWithWalletKey,
                         selection: $flow) { EmptyView() }
-                    
+
+                    NavigationLink(
+                        destination: ImportSeedPhraseBackupFileView(viewModel: BackupFileViewModel.init(recoveryService: defaultProvider.recoveryPhraseService(), onValidPhrase: { key in
+                            self.walletPrivateKey = key
+                        })),
+                        tag: Flow.recoverwithSeedPhraseBackup,
+                        selection: $flow) { EmptyView() }
+
                     optionsView()
                 }
                 

--- a/ConcordiumWallet/Features/NewOnboardingFlow/ImportSeedBasedWallet/ViewModels/ImportWalletPrivateKeyViewModel.swift
+++ b/ConcordiumWallet/Features/NewOnboardingFlow/ImportSeedBasedWallet/ViewModels/ImportWalletPrivateKeyViewModel.swift
@@ -34,7 +34,7 @@ final class ImportWalletPrivateKeyViewModel: ObservableObject {
         
     func validateCurrentInput() {
         if !currentInput.isEmpty {
-            if validateWalletPrivateKey() {
+            if recoveryService.isValidWalletPrivateKey(key: currentInput) {
                 walletPrivateKey = IdentifiableString(value: currentInput)
                 isValidPhrase = true
                 withAnimation {
@@ -53,47 +53,5 @@ final class ImportWalletPrivateKeyViewModel: ObservableObject {
         if let walletPrivateKey {
             onValidPrivateKey(walletPrivateKey)
         }
-    }
-    
-    private func validateWalletPrivateKey() -> Bool {
-        let hexPattern = "^[0-9a-fA-F]{128}$"
-        
-        do {
-            let regex = try NSRegularExpression(pattern: hexPattern)
-            let range = NSRange(location: 0, length: currentInput.utf16.count)
-            
-            if regex.firstMatch(in: currentInput, options: [], range: range) != nil {
-                let decodedBytes = try hexStringToByteArray(currentInput)
-                return decodedBytes.count == 64
-            } else {
-                return false
-            }
-        } catch {
-            return false
-        }
-    }
-
-
-    
-    private func hexStringToByteArray(_ hex: String) throws -> [UInt8] {
-        guard hex.count % 2 == 0 else {
-            throw NSError(domain: "Invalid hex string: length must be even", code: 0, userInfo: nil)
-        }
-
-        var bytes = [UInt8]()
-        var index = hex.startIndex
-        while index < hex.endIndex {
-            let nextIndex = hex.index(index, offsetBy: 2)
-            let byteString = String(hex[index..<nextIndex])
-            
-            if let byte = UInt8(byteString, radix: 16) {
-                bytes.append(byte)
-            } else {
-                throw NSError(domain: "Invalid hex string", code: 0, userInfo: nil)
-            }
-            
-            index = nextIndex
-        }
-        return bytes
     }
 }

--- a/ConcordiumWallet/Features/NewOnboardingFlow/SeedPhrase/RevealSeedPhraseView.swift
+++ b/ConcordiumWallet/Features/NewOnboardingFlow/SeedPhrase/RevealSeedPhraseView.swift
@@ -11,7 +11,8 @@ import MnemonicSwift
 
 final class RevealSeedPhraseViewModel: ObservableObject {
     @Published var mnenonic: [String] = []
-    
+    var backupFileURL: URL?
+    var pwHash: String = ""
     private let identitiesService: SeedIdentitiesService
     
     init(identitiesService: SeedIdentitiesService) {
@@ -22,6 +23,7 @@ final class RevealSeedPhraseViewModel: ObservableObject {
         Task {
             do {
                 let seed = try await identitiesService.mobileWallet.getRecoveryPhrase(pwHash: pwHash).joined(separator: " ")
+                self.pwHash = pwHash
                 await MainActor.run {
                     withAnimation(.bouncy) {
                         self.mnenonic = seed.components(separatedBy: " ")
@@ -32,6 +34,11 @@ final class RevealSeedPhraseViewModel: ObservableObject {
             }
         }
     }
+    
+    func createBackupFile() throws {
+        let encryptedSeedPhrase = try SeedPhraseEncryptionManager().encryptSeed(mnenonic.joined(separator: " "), password: pwHash)
+        backupFileURL = try SeedPhraseBackupManager().createPKPassFile(encryptedSeed: encryptedSeedPhrase)
+    }
 }
 
 struct RevealSeedPhraseView: View {
@@ -41,7 +48,7 @@ struct RevealSeedPhraseView: View {
 
     @State var shareText: ShareText?
     @State var isShowPasscodeViewShown: Bool = false
-    
+    @State var showExportSheet: Bool = false
     @Namespace private var animation
     
     var body: some View {
@@ -108,7 +115,27 @@ struct RevealSeedPhraseView: View {
                 }
             }
             .padding(.top, 22)
-            
+            if !viewModel.mnenonic.isEmpty {
+                HStack {
+                    Text("iCloud backup")
+                        .foregroundStyle(Color.Neutral.tint1)
+                        .font(.satoshi(size: 14, weight: .medium))
+                    
+                    Spacer()
+                    
+                    Button {
+                        do {
+                            try viewModel.createBackupFile()
+                            showExportSheet = true
+                        } catch {}
+                    } label: {
+                        Text("Backup now")
+                            .foregroundStyle(Color.attentionRed)
+                            .font(.satoshi(size: 14, weight: .medium))
+                    }
+                }
+            }
+
             Spacer()
         }
         .padding(.horizontal, 16)
@@ -130,6 +157,11 @@ struct RevealSeedPhraseView: View {
         }
         .passcodeInput(isPresented: $isShowPasscodeViewShown) { pwHash in
             viewModel.revealSeedPhrase(pwHash)
+        }
+        .sheet(isPresented: $showExportSheet) {
+            if let url = viewModel.backupFileURL {
+                BackupExportView(backupFileURL: url)
+            }
         }
     }
     

--- a/ConcordiumWallet/Features/NewOnboardingFlow/SeedPhrase/RevealSeedPhraseView.swift
+++ b/ConcordiumWallet/Features/NewOnboardingFlow/SeedPhrase/RevealSeedPhraseView.swift
@@ -9,10 +9,36 @@
 import SwiftUI
 import MnemonicSwift
 
+enum ICloudBackupError: Error {
+    case failedToSave
+    case failedToRetrieve
+    case failedToCreateFile
+    case iCloudNotAvailable
+    case generalError(Error)
+    
+    var errorLocalizedDescription: String {
+        switch self {
+        case .failedToSave:
+            return "Failed to save backup file to iCloud."
+        case .failedToRetrieve:
+            return "Failed to retrieve backup file from iCloud."
+        case .failedToCreateFile:
+            return "Failed to create backup file."
+        case .iCloudNotAvailable:
+            return "iCloud is not available."
+        case .generalError(let error):
+            return error.localizedDescription
+        }
+    }
+}
+
 final class RevealSeedPhraseViewModel: ObservableObject {
     @Published var mnenonic: [String] = []
-    var backupFileURL: URL?
+    @Published var error: ICloudBackupError?
+    @Published var showSuccessPopup: Bool = false
+    @Published var backupFileURL: URL?
     var pwHash: String = ""
+    @Published var hasBackedUp: Bool = false
     private let identitiesService: SeedIdentitiesService
     
     init(identitiesService: SeedIdentitiesService) {
@@ -35,10 +61,32 @@ final class RevealSeedPhraseViewModel: ObservableObject {
         }
     }
     
-    func createBackupFile() throws {
-        let encryptedSeedPhrase = try SeedPhraseEncryptionManager().encryptSeed(mnenonic.joined(separator: " "), password: "pwHash")
-        let fileURL = try SeedPhraseBackupManager().createPKPassFile(encryptedSeed: encryptedSeedPhrase)
-        backupFileURL = try SeedPhraseBackupManager().saveToICloud(fileURL: fileURL)
+    func createBackupFile() {
+        do {
+            let encryptedSeedPhrase = try SeedPhraseEncryptionManager().encryptSeed(mnenonic.joined(separator: " "), password: "pwHash")
+            SeedPhraseBackupManager().createPKPassFileInICloud(encryptedSeed: encryptedSeedPhrase) { result in
+                switch result {
+                case .success(let url):
+                    self.backupFileURL = url
+                case .failure:
+                    self.error = .failedToSave
+                }
+            }
+        } catch(let error) {
+            if let iCloudError = error as? ICloudBackupError {
+                self.error = iCloudError
+            } else {
+                self.error = ICloudBackupError.generalError(error)
+            }
+        }
+    }
+    
+    func removeAllBackupFiles() {
+        SeedPhraseBackupManager().deleteAllICloudBackups()
+    }
+    
+    func doesBackupFileExists() -> Bool {
+        SeedPhraseBackupManager().isBackupFileCreated() || hasBackedUp
     }
 }
 
@@ -46,7 +94,7 @@ struct RevealSeedPhraseView: View {
     @ObservedObject var viewModel: RevealSeedPhraseViewModel
     
     @SwiftUI.Environment(\.dismiss) var dismiss
-
+    @State private var isShowingError = false
     @State var shareText: ShareText?
     @State var isShowPasscodeViewShown: Bool = false
     @State var showExportSheet: Bool = false
@@ -121,18 +169,20 @@ struct RevealSeedPhraseView: View {
                     Text("iCloud backup")
                         .foregroundStyle(Color.Neutral.tint1)
                         .font(.satoshi(size: 14, weight: .medium))
-                    
                     Spacer()
-                    
-                    Button {
-                        do {
-                            try viewModel.createBackupFile()
-                            showExportSheet = true
-                        } catch {}
-                    } label: {
-                        Text("Backup now")
-                            .foregroundStyle(Color.attentionRed)
+                    if viewModel.doesBackupFileExists() {
+                        Text("Active")
+                            .foregroundStyle(Color.successGreen)
                             .font(.satoshi(size: 14, weight: .medium))
+                    } else {
+                        Button {
+                            viewModel.createBackupFile()
+                            showExportSheet = true
+                        } label: {
+                            Text("Backup now")
+                                .foregroundStyle(Color.attentionRed)
+                                .font(.satoshi(size: 14, weight: .medium))
+                        }
                     }
                 }
             }
@@ -160,9 +210,31 @@ struct RevealSeedPhraseView: View {
             viewModel.revealSeedPhrase(pwHash)
         }
         .sheet(isPresented: $showExportSheet) {
-            if let url = viewModel.backupFileURL {
-                BackupExportView(backupFileURL: url)
+            if let url = viewModel.backupFileURL, FileManager.default.fileExists(atPath: url.path) {
+                BackupExportView(backupFileURL: url) { didExport in
+                        if didExport {
+                            viewModel.hasBackedUp = true
+                            viewModel.showSuccessPopup = true
+                        } else {
+                            print("User cancelled backup export")
+                        }
+                    }
             }
+        }
+        .toast(isPresented: $viewModel.showSuccessPopup, position: .bottom) {
+            ToastGradientView(title: "seed.icloud.backup.success".localized, imageName: "ico_successfully")
+        }
+        .onReceive(viewModel.$error) { newError in
+            isShowingError = newError != nil
+        }
+        .alert(isPresented: $isShowingError) {
+            Alert(
+                title: Text("Error"),
+                message: Text(viewModel.error?.errorLocalizedDescription ?? "Unknown error"),
+                dismissButton: .default(Text("OK")) {
+                    viewModel.error = nil
+                }
+            )
         }
     }
     

--- a/ConcordiumWallet/Features/NewOnboardingFlow/SeedPhrase/RevealSeedPhraseView.swift
+++ b/ConcordiumWallet/Features/NewOnboardingFlow/SeedPhrase/RevealSeedPhraseView.swift
@@ -37,10 +37,10 @@ final class RevealSeedPhraseViewModel: ObservableObject {
     @Published var error: ICloudBackupError?
     @Published var showSuccessPopup: Bool = false
     @Published var backupFileURL: URL?
-    var pwHash: String = ""
-    @Published var hasBackedUp: Bool = false
+    @Published var isBackupAvailable: Bool = false
+
     private let identitiesService: SeedIdentitiesService
-    
+
     init(identitiesService: SeedIdentitiesService) {
         self.identitiesService = identitiesService
     }
@@ -49,7 +49,6 @@ final class RevealSeedPhraseViewModel: ObservableObject {
         Task {
             do {
                 let seed = try await identitiesService.mobileWallet.getRecoveryPhrase(pwHash: pwHash).joined(separator: " ")
-                self.pwHash = pwHash
                 await MainActor.run {
                     withAnimation(.bouncy) {
                         self.mnenonic = seed.components(separatedBy: " ")
@@ -68,6 +67,8 @@ final class RevealSeedPhraseViewModel: ObservableObject {
                 switch result {
                 case .success(let url):
                     self.backupFileURL = url
+                    self.updateBackupStatus()
+                    self.showSuccessPopup = true
                 case .failure:
                     self.error = .failedToSave
                 }
@@ -85,8 +86,8 @@ final class RevealSeedPhraseViewModel: ObservableObject {
         SeedPhraseBackupManager().deleteAllICloudBackups()
     }
     
-    func doesBackupFileExists() -> Bool {
-        SeedPhraseBackupManager().isBackupFileCreated() || hasBackedUp
+    func updateBackupStatus() {
+        isBackupAvailable = SeedPhraseBackupManager().isBackupFileCreated()
     }
 }
 
@@ -164,20 +165,19 @@ struct RevealSeedPhraseView: View {
                 }
             }
             .padding(.top, 22)
-            if !viewModel.mnenonic.isEmpty {
+            if !viewModel.mnenonic.isEmpty && AppSettings.isOnboardingFinished {
                 HStack {
                     Text("iCloud backup")
                         .foregroundStyle(Color.Neutral.tint1)
                         .font(.satoshi(size: 14, weight: .medium))
                     Spacer()
-                    if viewModel.doesBackupFileExists() {
+                    if viewModel.isBackupAvailable {
                         Text("Active")
                             .foregroundStyle(Color.successGreen)
                             .font(.satoshi(size: 14, weight: .medium))
                     } else {
                         Button {
                             viewModel.createBackupFile()
-                            showExportSheet = true
                         } label: {
                             Text("Backup now")
                                 .foregroundStyle(Color.attentionRed)
@@ -209,17 +209,9 @@ struct RevealSeedPhraseView: View {
         .passcodeInput(isPresented: $isShowPasscodeViewShown) { pwHash in
             viewModel.revealSeedPhrase(pwHash)
         }
-        .sheet(isPresented: $showExportSheet) {
-            if let url = viewModel.backupFileURL, FileManager.default.fileExists(atPath: url.path) {
-                BackupExportView(backupFileURL: url) { didExport in
-                        if didExport {
-                            viewModel.hasBackedUp = true
-                            viewModel.showSuccessPopup = true
-                        } else {
-                            print("User cancelled backup export")
-                        }
-                    }
-            }
+        .onAppear {
+            viewModel.removeAllBackupFiles()
+            viewModel.updateBackupStatus()
         }
         .toast(isPresented: $viewModel.showSuccessPopup, position: .bottom) {
             ToastGradientView(title: "seed.icloud.backup.success".localized, imageName: "ico_successfully")

--- a/ConcordiumWallet/Features/NewOnboardingFlow/SeedPhrase/RevealSeedPhraseView.swift
+++ b/ConcordiumWallet/Features/NewOnboardingFlow/SeedPhrase/RevealSeedPhraseView.swift
@@ -36,8 +36,9 @@ final class RevealSeedPhraseViewModel: ObservableObject {
     }
     
     func createBackupFile() throws {
-        let encryptedSeedPhrase = try SeedPhraseEncryptionManager().encryptSeed(mnenonic.joined(separator: " "), password: pwHash)
-        backupFileURL = try SeedPhraseBackupManager().createPKPassFile(encryptedSeed: encryptedSeedPhrase)
+        let encryptedSeedPhrase = try SeedPhraseEncryptionManager().encryptSeed(mnenonic.joined(separator: " "), password: "pwHash")
+        let fileURL = try SeedPhraseBackupManager().createPKPassFile(encryptedSeed: encryptedSeedPhrase)
+        backupFileURL = try SeedPhraseBackupManager().saveToICloud(fileURL: fileURL)
     }
 }
 

--- a/ConcordiumWallet/Features/RecoveryPhrase/RecoveryPhraseService.swift
+++ b/ConcordiumWallet/Features/RecoveryPhrase/RecoveryPhraseService.swift
@@ -8,6 +8,7 @@
 
 import MnemonicSwift
 import Combine
+import Foundation
 
 protocol RecoveryPhraseServiceProtocol {
     func generateRecoveryPhrase() -> Result<RecoveryPhrase, Error>
@@ -21,6 +22,8 @@ protocol RecoveryPhraseServiceProtocol {
     func store(recoveryPhrase: RecoveryPhrase, with pwHash: String) async throws -> Seed
     
     func store(walletPrivateKey: String, with pwHash: String) async throws -> Seed
+    
+    func isValidWalletPrivateKey(key: String) -> Bool
 }
 
 extension RecoveryPhraseServiceProtocol {
@@ -93,5 +96,49 @@ private extension RandomAccessCollection where Element: Equatable {
         }
         
         return result
+    }
+}
+
+extension RecoveryPhraseServiceProtocol {
+    func isValidWalletPrivateKey(key: String) -> Bool {
+        let hexPattern = "^[0-9a-fA-F]{128}$"
+        
+        do {
+            let regex = try NSRegularExpression(pattern: hexPattern)
+            let range = NSRange(location: 0, length: key.utf16.count)
+            
+            if regex.firstMatch(in: key, options: [], range: range) != nil {
+                let decodedBytes = try hexStringToByteArray(key)
+                return decodedBytes.count == 64
+            } else {
+                return false
+            }
+        } catch {
+            return false
+        }
+    }
+
+
+    
+    private func hexStringToByteArray(_ hex: String) throws -> [UInt8] {
+        guard hex.count % 2 == 0 else {
+            throw NSError(domain: "Invalid hex string: length must be even", code: 0, userInfo: nil)
+        }
+
+        var bytes = [UInt8]()
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let nextIndex = hex.index(index, offsetBy: 2)
+            let byteString = String(hex[index..<nextIndex])
+            
+            if let byte = UInt8(byteString, radix: 16) {
+                bytes.append(byte)
+            } else {
+                throw NSError(domain: "Invalid hex string", code: 0, userInfo: nil)
+            }
+            
+            index = nextIndex
+        }
+        return bytes
     }
 }

--- a/ConcordiumWallet/Features/SeedBackup/BackupExportFileView.swift
+++ b/ConcordiumWallet/Features/SeedBackup/BackupExportFileView.swift
@@ -1,0 +1,21 @@
+//
+//  BackupExportFileView.swift
+//  CryptoX
+//
+//  Created by Zhanna Komar on 09.06.2025.
+//  Copyright © 2025 pioneeringtechventures. All rights reserved.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct BackupExportView: UIViewControllerRepresentable {
+    let backupFileURL: URL
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(forExporting: [backupFileURL], asCopy: true)
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+}

--- a/ConcordiumWallet/Features/SeedBackup/BackupExportFileView.swift
+++ b/ConcordiumWallet/Features/SeedBackup/BackupExportFileView.swift
@@ -11,11 +11,33 @@ import UniformTypeIdentifiers
 
 struct BackupExportView: UIViewControllerRepresentable {
     let backupFileURL: URL
+    let onExportCompletion: (Bool) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(onCompletion: onExportCompletion)
+    }
 
     func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
         let picker = UIDocumentPickerViewController(forExporting: [backupFileURL], asCopy: true)
+        picker.delegate = context.coordinator
         return picker
     }
 
     func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+    class Coordinator: NSObject, UIDocumentPickerDelegate {
+        let onCompletion: (Bool) -> Void
+
+        init(onCompletion: @escaping (Bool) -> Void) {
+            self.onCompletion = onCompletion
+        }
+
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            onCompletion(true)
+        }
+
+        func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+            onCompletion(false)
+        }
+    }
 }

--- a/ConcordiumWallet/Features/SeedBackup/BackupFileViewModel.swift
+++ b/ConcordiumWallet/Features/SeedBackup/BackupFileViewModel.swift
@@ -16,7 +16,7 @@ struct BackupFile: Identifiable {
 }
 
 final class BackupFileViewModel: ObservableObject {
-    let onValidPhrase: (IdentifiableString) -> Void
+    let onValidPhrase: (RecoveryPhrase) -> Void
     @Published var error: String? = nil
     @Published var isValidPhrase: Bool = false
     @Published var showImportButton: Bool = false
@@ -25,37 +25,63 @@ final class BackupFileViewModel: ObservableObject {
     private let recoveryService: RecoveryPhraseServiceProtocol
     private var cancellables = Set<AnyCancellable>()
 
-    init(recoveryService: RecoveryPhraseServiceProtocol, onValidPhrase: @escaping (IdentifiableString) -> Void) {
+    init(recoveryService: RecoveryPhraseServiceProtocol, onValidPhrase: @escaping (RecoveryPhrase) -> Void) {
         self.recoveryService = recoveryService
         self.onValidPhrase = onValidPhrase
-        loadBackupFiles()
+        loadFilesFromIcloud()
     }
+    
+    func loadFilesFromIcloud() {
+        guard let iCloudURL = FileManager.default.url(forUbiquityContainerIdentifier: "iCloud.com.pioneeringtechventures.cryptox") else {
+            print("iCloud not available or container not found")
+            return
+        }
 
-    func loadBackupFiles() {
-        let fileManager = FileManager.default
-        let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let documentsURL = iCloudURL.appendingPathComponent("Documents/Backups")
         
         do {
-            let fileURLs = try fileManager.contentsOfDirectory(at: documentsURL, includingPropertiesForKeys: nil)
-            let pkpassFiles = fileURLs.filter { $0.pathExtension == "pkpass" && $0.absoluteString.contains("cryptoX") }
+            let contents = try FileManager.default.contentsOfDirectory(at: documentsURL, includingPropertiesForKeys: nil)
+            let pkpassFiles = contents.filter { $0.pathExtension == "pkpass" && $0.absoluteString.contains("cryptoX") }
+            
+            for fileURL in pkpassFiles {
+                try ensureFileIsDownloaded(at: fileURL)
+                print("Ready to use: \(fileURL.lastPathComponent)")
+            }
             backupFiles = pkpassFiles.map { BackupFile(url: $0) }.sorted(by: { $0.name > $1.name })
         } catch {
-            print("Error reading backup files: \(error)")
+            print("Failed to list iCloud documents: \(error)")
         }
     }
     
-    func importAction(data: Data, pwHash: String) {
+    func importAction(url: URL, pwHash: String) {
         do {
-            let decrypted = try SeedPhraseEncryptionManager().decryptSeed(data, password: pwHash)
-            print("Decrypted seed: \(decrypted)")
-            if recoveryService.isValidWalletPrivateKey(key: decrypted) {
-                let identifiableKey = IdentifiableString(value: decrypted)
-                self.onValidPhrase(identifiableKey)
-            } else {
+            let seedPhrase = try SeedPhraseEncryptionManager().decryptBackupFile(at: url)
+            print("Decrypted seed: \(seedPhrase)")
+            switch recoveryService.validate(recoveryPhrase: seedPhrase.components(separatedBy: " ")) {
+            case .success:
+                let recoveryPhrase = try RecoveryPhrase(phrase: seedPhrase)
+                self.onValidPhrase(recoveryPhrase)
+            case .failure:
                 error = "recoveryphrase.recover.input.validationerror".localized
             }
         } catch {
             print("Error while importing backup file")
+        }
+    }
+    
+    private func ensureFileIsDownloaded(at url: URL) throws {
+        let resourceValues = try url.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey])
+        
+        if let status = resourceValues.ubiquitousItemDownloadingStatus {
+            switch status {
+            case .notDownloaded:
+                try FileManager.default.startDownloadingUbiquitousItem(at: url)
+            case .current, .downloaded:
+                // File is available
+                break
+            default:
+                break
+            }
         }
     }
 }

--- a/ConcordiumWallet/Features/SeedBackup/BackupFileViewModel.swift
+++ b/ConcordiumWallet/Features/SeedBackup/BackupFileViewModel.swift
@@ -13,6 +13,7 @@ struct BackupFile: Identifiable {
     let id = UUID()
     let url: URL
     var name: String { url.lastPathComponent }
+    let createdDate: Date?
 }
 
 final class BackupFileViewModel: ObservableObject {
@@ -37,17 +38,17 @@ final class BackupFileViewModel: ObservableObject {
             return
         }
 
-        let documentsURL = iCloudURL.appendingPathComponent("Documents/Backups")
+        let documentsURL = iCloudURL.appendingPathComponent("Documents/")
         
         do {
             let contents = try FileManager.default.contentsOfDirectory(at: documentsURL, includingPropertiesForKeys: nil)
-            let pkpassFiles = contents.filter { $0.pathExtension == "pkpass" && $0.absoluteString.contains("cryptoX") }
+            let pkpassFiles = contents.filter { $0.pathExtension == "pkpass"}
             
             for fileURL in pkpassFiles {
                 try ensureFileIsDownloaded(at: fileURL)
                 print("Ready to use: \(fileURL.lastPathComponent)")
             }
-            backupFiles = pkpassFiles.map { BackupFile(url: $0) }.sorted(by: { $0.name > $1.name })
+            backupFiles = pkpassFiles.map { BackupFile(url: $0, createdDate: getCreationDate(of: $0)) }.sorted(by: { $0.name > $1.name })
         } catch {
             print("Failed to list iCloud documents: \(error)")
         }
@@ -82,6 +83,16 @@ final class BackupFileViewModel: ObservableObject {
             default:
                 break
             }
+        }
+    }
+    
+    func getCreationDate(of fileURL: URL) -> Date? {
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.creationDateKey])
+            return resourceValues.creationDate
+        } catch {
+            print("Error fetching creation date: \(error)")
+            return nil
         }
     }
 }

--- a/ConcordiumWallet/Features/SeedBackup/BackupFileViewModel.swift
+++ b/ConcordiumWallet/Features/SeedBackup/BackupFileViewModel.swift
@@ -1,0 +1,61 @@
+//
+//  BackupFileViewModel.swift
+//  CryptoX
+//
+//  Created by Zhanna Komar on 09.06.2025.
+//  Copyright © 2025 pioneeringtechventures. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+struct BackupFile: Identifiable {
+    let id = UUID()
+    let url: URL
+    var name: String { url.lastPathComponent }
+}
+
+final class BackupFileViewModel: ObservableObject {
+    let onValidPhrase: (IdentifiableString) -> Void
+    @Published var error: String? = nil
+    @Published var isValidPhrase: Bool = false
+    @Published var showImportButton: Bool = false
+    @Published var backupFiles: [BackupFile] = []
+    
+    private let recoveryService: RecoveryPhraseServiceProtocol
+    private var cancellables = Set<AnyCancellable>()
+
+    init(recoveryService: RecoveryPhraseServiceProtocol, onValidPhrase: @escaping (IdentifiableString) -> Void) {
+        self.recoveryService = recoveryService
+        self.onValidPhrase = onValidPhrase
+        loadBackupFiles()
+    }
+
+    func loadBackupFiles() {
+        let fileManager = FileManager.default
+        let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        
+        do {
+            let fileURLs = try fileManager.contentsOfDirectory(at: documentsURL, includingPropertiesForKeys: nil)
+            let pkpassFiles = fileURLs.filter { $0.pathExtension == "pkpass" && $0.absoluteString.contains("cryptoX") }
+            backupFiles = pkpassFiles.map { BackupFile(url: $0) }.sorted(by: { $0.name > $1.name })
+        } catch {
+            print("Error reading backup files: \(error)")
+        }
+    }
+    
+    func importAction(data: Data, pwHash: String) {
+        do {
+            let decrypted = try SeedPhraseEncryptionManager().decryptSeed(data, password: pwHash)
+            print("Decrypted seed: \(decrypted)")
+            if recoveryService.isValidWalletPrivateKey(key: decrypted) {
+                let identifiableKey = IdentifiableString(value: decrypted)
+                self.onValidPhrase(identifiableKey)
+            } else {
+                error = "recoveryphrase.recover.input.validationerror".localized
+            }
+        } catch {
+            print("Error while importing backup file")
+        }
+    }
+}

--- a/ConcordiumWallet/Features/SeedBackup/ImportSeedPhraseBackupFileView.swift
+++ b/ConcordiumWallet/Features/SeedBackup/ImportSeedPhraseBackupFileView.swift
@@ -7,33 +7,75 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct ImportSeedPhraseBackupFileView: View {
-    @StateObject private var viewModel = BackupFileViewModel()
+    @ObservedObject var viewModel: BackupFileViewModel
+    @State var isShowPasscodeViewShown: Bool = false
+    @SwiftUI.Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        NavigationView {
-            List(viewModel.backupFiles) { file in
-                HStack {
-                    Text(file.name)
-                        .lineLimit(1)
-                    Spacer()
-                    Button {
-                        shareBackup(file.url)
-                    } label: {
-                        Image(systemName: "square.and.arrow.up")
-                    }
+        VStack(spacing: 40) {
+            VStack(spacing: 12) {
+                Text("import.walletPrivateKey.title".localized)
+                    .font(.satoshi(size: 24, weight: .medium))
+                    .foregroundColor(Color.Neutral.tint1)
+                    .multilineTextAlignment(.center)
+                Text("import.walletPrivateKey.subtitle".localized)
+                    .font(.satoshi(size: 14, weight: .regular))
+                    .foregroundColor(Color.Neutral.tint2)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            
+            List {
+                ForEach(viewModel.backupFiles) { file in
+                    backupCell(title: file.name)
+                        .listRowBackground(Color.clear)
+                        .padding(.top, 8)
+                        .onTapGesture {
+                            viewModel.importAction(url: file.url, pwHash: "")
+                        }
                 }
             }
-            .navigationTitle("Backups")
+            .listStyle(.plain)
+            .listRowSeparator(.hidden)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationBarBackButtonHidden(true)
+        .modifier(AppBackgroundModifier())
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "arrow.backward")
+                        .foregroundColor(Color.Neutral.tint1)
+                        .frame(width: 35, height: 35)
+                        .contentShape(.circle)
+                }
+            }
         }
     }
-
-    func shareBackup(_ url: URL) {
-        let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-        if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let root = scene.windows.first?.rootViewController {
-            root.present(activityVC, animated: true)
+    
+    @ViewBuilder
+    func backupCell(title: String) -> some View {
+        HStack(alignment: .center, spacing: 17) {
+            Image(systemName: "icloud.and.arrow.down")
+                    .resizable()
+                    .frame(width: 40, height: 40)
+                HStack(spacing: 0) {
+                    Text(title)
+                        .font(.satoshi(size: 15, weight: .medium))
+                }
         }
+        .listRowInsets(EdgeInsets())
+        .listRowSeparator(.hidden)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 11)
+        .background(.grey2.opacity(0.3))
+        .cornerRadius(12)
     }
 }

--- a/ConcordiumWallet/Features/SeedBackup/ImportSeedPhraseBackupFileView.swift
+++ b/ConcordiumWallet/Features/SeedBackup/ImportSeedPhraseBackupFileView.swift
@@ -1,0 +1,39 @@
+//
+//  ImportSeedPhraseBackupFileView.swift
+//  CryptoX
+//
+//  Created by Zhanna Komar on 09.06.2025.
+//  Copyright © 2025 pioneeringtechventures. All rights reserved.
+//
+
+import SwiftUI
+
+struct ImportSeedPhraseBackupFileView: View {
+    @StateObject private var viewModel = BackupFileViewModel()
+
+    var body: some View {
+        NavigationView {
+            List(viewModel.backupFiles) { file in
+                HStack {
+                    Text(file.name)
+                        .lineLimit(1)
+                    Spacer()
+                    Button {
+                        shareBackup(file.url)
+                    } label: {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }
+            .navigationTitle("Backups")
+        }
+    }
+
+    func shareBackup(_ url: URL) {
+        let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let root = scene.windows.first?.rootViewController {
+            root.present(activityVC, animated: true)
+        }
+    }
+}

--- a/ConcordiumWallet/Features/SeedBackup/ImportSeedPhraseBackupFileView.swift
+++ b/ConcordiumWallet/Features/SeedBackup/ImportSeedPhraseBackupFileView.swift
@@ -17,11 +17,11 @@ struct ImportSeedPhraseBackupFileView: View {
     var body: some View {
         VStack(spacing: 40) {
             VStack(spacing: 12) {
-                Text("import.walletPrivateKey.title".localized)
+                Text("import.icloudBackup.title".localized)
                     .font(.satoshi(size: 24, weight: .medium))
                     .foregroundColor(Color.Neutral.tint1)
                     .multilineTextAlignment(.center)
-                Text("import.walletPrivateKey.subtitle".localized)
+                Text("import.icloudBackup.subtitle".localized)
                     .font(.satoshi(size: 14, weight: .regular))
                     .foregroundColor(Color.Neutral.tint2)
                     .multilineTextAlignment(.center)
@@ -30,7 +30,7 @@ struct ImportSeedPhraseBackupFileView: View {
             
             List {
                 ForEach(viewModel.backupFiles) { file in
-                    backupCell(title: file.name)
+                    backupCell(title: file.name, date: file.createdDate)
                         .listRowBackground(Color.clear)
                         .padding(.top, 8)
                         .onTapGesture {
@@ -42,7 +42,8 @@ struct ImportSeedPhraseBackupFileView: View {
             .listRowSeparator(.hidden)
         }
         .padding(.horizontal, 18)
-        .padding(.vertical, 40)
+        .padding(.top, 20)
+        .padding(.bottom, 40)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationBarBackButtonHidden(true)
         .modifier(AppBackgroundModifier())
@@ -61,16 +62,23 @@ struct ImportSeedPhraseBackupFileView: View {
     }
     
     @ViewBuilder
-    func backupCell(title: String) -> some View {
+    func backupCell(title: String, date: Date?) -> some View {
         HStack(alignment: .center, spacing: 17) {
             Image(systemName: "icloud.and.arrow.down")
                     .resizable()
                     .frame(width: 40, height: 40)
-                HStack(spacing: 0) {
-                    Text(title)
-                        .font(.satoshi(size: 15, weight: .medium))
+            VStack(alignment: .leading, spacing: 5) {
+                Text(title)
+                    .font(.satoshi(size: 15, weight: .medium))
+                    .foregroundStyle(.white)
+                if let date {
+                    Text(date.formatted())
+                        .font(.satoshi(size: 13, weight: .medium))
+                        .foregroundStyle(.whiteMainOpacity50)
                 }
+            }
         }
+        .frame(maxWidth: .infinity)
         .listRowInsets(EdgeInsets())
         .listRowSeparator(.hidden)
         .padding(.horizontal, 12)

--- a/ConcordiumWallet/Features/SeedBackup/SeedPhraseBackupManager.swift
+++ b/ConcordiumWallet/Features/SeedBackup/SeedPhraseBackupManager.swift
@@ -91,4 +91,19 @@ final class SeedPhraseBackupManager {
         
         return archive.url
     }
+    
+    func saveToICloud(fileURL: URL) throws -> URL {
+        guard let iCloudURL = FileManager.default.url(forUbiquityContainerIdentifier: "iCloud.com.pioneeringtechventures.cryptox") else {
+            throw NSError(domain: "iCloudError", code: 1, userInfo: [NSLocalizedDescriptionKey: "iCloud not available"])
+        }
+
+        // Save into "Documents/Backups" inside iCloud Drive
+        let destinationFolder = iCloudURL.appendingPathComponent("Documents/Backups", isDirectory: true)
+        try FileManager.default.createDirectory(at: destinationFolder, withIntermediateDirectories: true)
+
+        let destinationURL = destinationFolder.appendingPathComponent(fileURL.lastPathComponent)
+        try FileManager.default.copyItem(at: fileURL, to: destinationURL)
+
+        return destinationURL
+    }
 }

--- a/ConcordiumWallet/Features/SeedBackup/SeedPhraseBackupManager.swift
+++ b/ConcordiumWallet/Features/SeedBackup/SeedPhraseBackupManager.swift
@@ -1,0 +1,94 @@
+//
+//  SeedPhraseBackupManager.swift
+//  CryptoX
+//
+//  Created by Zhanna Komar on 09.06.2025.
+//  Copyright © 2025 pioneeringtechventures. All rights reserved.
+//
+
+import Foundation
+import Security
+import Compression
+import CommonCrypto
+import ZIPFoundation
+import PassKit
+
+final class SeedPhraseBackupManager {
+    
+    private func createPassJSON(with encryptedSeed: Data) -> Data {
+        let base64Seed = encryptedSeed.base64EncodedString()
+        let pass: [String: Any] = [
+            "description": "Seed Backup",
+            "formatVersion": 1,
+            "organizationName": "CryptoX",
+            "passTypeIdentifier": "pass.com.CryptoX.seedbackup",
+            "serialNumber": UUID().uuidString,
+            "generic": [
+                "primaryFields": [
+                    [
+                        "key": "seed",
+                        "label": "Encrypted Seed",
+                        "value": base64Seed
+                    ]
+                ]
+            ]
+        ]
+        
+        return try! JSONSerialization.data(withJSONObject: pass, options: .prettyPrinted)
+    }
+    
+    private func sha1Hash(of data: Data) -> String {
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA1($0.baseAddress, CC_LONG(data.count), &digest)
+        }
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+    
+    private func makeBackupFileURL() -> URL {
+        let fileManager = FileManager.default
+        let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+        let dateString = formatter.string(from: Date())
+        
+        let filename = "cryptoX_backup_\(dateString).pkpass"
+        return documentsURL.appendingPathComponent(filename)
+    }
+    
+    func createPKPassFile(encryptedSeed: Data) throws -> URL {
+        let fileManager = FileManager.default
+        let tempDirectory = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fileManager.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        
+        defer { try? fileManager.removeItem(at: tempDirectory) }
+        
+        // Save seed file
+        let seedFileURL = tempDirectory.appendingPathComponent("seed.json")
+        try encryptedSeed.write(to: seedFileURL)
+        
+        // Generate pass.json
+        let passData = createPassJSON(with: encryptedSeed)
+        let passFileURL = tempDirectory.appendingPathComponent("pass.json")
+        try passData.write(to: passFileURL)
+        
+        // Generate manifest
+        let manifest: [String: String] = [
+            "seed.json": sha1Hash(of: encryptedSeed),
+            "pass.json": sha1Hash(of: passData)
+        ]
+        let manifestData = try JSONSerialization.data(withJSONObject: manifest, options: [])
+        let manifestURL = tempDirectory.appendingPathComponent("manifest.json")
+        try manifestData.write(to: manifestURL)
+        
+        // Create ZIP file
+        let destinationURL = makeBackupFileURL()
+        let archive = try Archive(url: destinationURL, accessMode: .create)
+        try archive.addEntry(with: "seed.json", relativeTo: tempDirectory)
+        try archive.addEntry(with: "pass.json", relativeTo: tempDirectory)
+        try archive.addEntry(with: "manifest.json", relativeTo: tempDirectory)
+        
+        return archive.url
+    }
+}

--- a/ConcordiumWallet/Features/SeedBackup/SeedPhraseBackupManager.swift
+++ b/ConcordiumWallet/Features/SeedBackup/SeedPhraseBackupManager.swift
@@ -14,6 +14,8 @@ import ZIPFoundation
 import PassKit
 
 final class SeedPhraseBackupManager {
+    private let fileStorageURL = "Documents/"
+    private let ubiquityContainerIdentifier = "iCloud.com.pioneeringtechventures.cryptox"
     
     private func createPassJSON(with encryptedSeed: Data) -> Data {
         let base64Seed = encryptedSeed.base64EncodedString()
@@ -45,65 +47,129 @@ final class SeedPhraseBackupManager {
         return digest.map { String(format: "%02x", $0) }.joined()
     }
     
-    private func makeBackupFileURL() -> URL {
+    private func getBackupFileURL(toICloud: Bool) -> URL? {
         let fileManager = FileManager.default
-        let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
-        let dateString = formatter.string(from: Date())
-        
-        let filename = "cryptoX_backup_\(dateString).pkpass"
-        return documentsURL.appendingPathComponent(filename)
-    }
-    
-    func createPKPassFile(encryptedSeed: Data) throws -> URL {
-        let fileManager = FileManager.default
-        let tempDirectory = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        try fileManager.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
-        
-        defer { try? fileManager.removeItem(at: tempDirectory) }
-        
-        // Save seed file
-        let seedFileURL = tempDirectory.appendingPathComponent("seed.json")
-        try encryptedSeed.write(to: seedFileURL)
-        
-        // Generate pass.json
-        let passData = createPassJSON(with: encryptedSeed)
-        let passFileURL = tempDirectory.appendingPathComponent("pass.json")
-        try passData.write(to: passFileURL)
-        
-        // Generate manifest
-        let manifest: [String: String] = [
-            "seed.json": sha1Hash(of: encryptedSeed),
-            "pass.json": sha1Hash(of: passData)
-        ]
-        let manifestData = try JSONSerialization.data(withJSONObject: manifest, options: [])
-        let manifestURL = tempDirectory.appendingPathComponent("manifest.json")
-        try manifestData.write(to: manifestURL)
-        
-        // Create ZIP file
-        let destinationURL = makeBackupFileURL()
-        let archive = try Archive(url: destinationURL, accessMode: .create)
-        try archive.addEntry(with: "seed.json", relativeTo: tempDirectory)
-        try archive.addEntry(with: "pass.json", relativeTo: tempDirectory)
-        try archive.addEntry(with: "manifest.json", relativeTo: tempDirectory)
-        
-        return archive.url
-    }
-    
-    func saveToICloud(fileURL: URL) throws -> URL {
-        guard let iCloudURL = FileManager.default.url(forUbiquityContainerIdentifier: "iCloud.com.pioneeringtechventures.cryptox") else {
-            throw NSError(domain: "iCloudError", code: 1, userInfo: [NSLocalizedDescriptionKey: "iCloud not available"])
+
+        var baseURL: URL?
+        if toICloud {
+            baseURL = fileManager.url(forUbiquityContainerIdentifier: ubiquityContainerIdentifier)?
+                .appendingPathComponent(fileStorageURL)
+        } else {
+            baseURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
         }
 
-        // Save into "Documents/Backups" inside iCloud Drive
-        let destinationFolder = iCloudURL.appendingPathComponent("Documents/Backups", isDirectory: true)
-        try FileManager.default.createDirectory(at: destinationFolder, withIntermediateDirectories: true)
+        guard let rootURL = baseURL else { return nil }
 
-        let destinationURL = destinationFolder.appendingPathComponent(fileURL.lastPathComponent)
-        try FileManager.default.copyItem(at: fileURL, to: destinationURL)
+        var schemaName = ""
+        #if MAINNET
+            schemaName = "Mainnet"
+        #elseif TESTNET
+            schemaName = "Testnet"
+        #endif
 
-        return destinationURL
+        let filename = "\(schemaName) backup_\(getFirstAccountName()).pkpass"
+        return rootURL.appendingPathComponent(filename)
+    }
+    
+    private func getFirstAccountName() -> String {
+        return ServicesProvider.defaultProvider().storageManager().getAccounts().first?.displayName ?? ""
+
+    }
+    
+    func createPKPassFileInICloud(
+        encryptedSeed: Data,
+        completion: @escaping (Result<URL, ICloudBackupError>) -> Void
+    ) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let fileManager = FileManager.default
+
+            let tempDirectory = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+            do {
+                try fileManager.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+                defer { try? fileManager.removeItem(at: tempDirectory) }
+
+                // Create seed.json
+                let seedFileURL = tempDirectory.appendingPathComponent("seed.json")
+                try encryptedSeed.write(to: seedFileURL)
+
+                // Create pass.json
+                let passData = self.createPassJSON(with: encryptedSeed)
+                let passFileURL = tempDirectory.appendingPathComponent("pass.json")
+                try passData.write(to: passFileURL)
+
+                // Create manifest.json
+                let manifest: [String: String] = [
+                    "seed.json": self.sha1Hash(of: encryptedSeed),
+                    "pass.json": self.sha1Hash(of: passData)
+                ]
+                let manifestData = try JSONSerialization.data(withJSONObject: manifest, options: [])
+                let manifestURL = tempDirectory.appendingPathComponent("manifest.json")
+                try manifestData.write(to: manifestURL)
+
+                // Ensure iCloud URL exists
+                guard let destinationURL = self.getBackupFileURL(toICloud: true) else {
+                    completion(.failure(.iCloudNotAvailable))
+                    return
+                }
+
+                let destinationFolder = destinationURL.deletingLastPathComponent()
+                try fileManager.createDirectory(at: destinationFolder, withIntermediateDirectories: true)
+
+                if fileManager.fileExists(atPath: destinationURL.path) {
+                    try fileManager.removeItem(at: destinationURL)
+                }
+                
+                // Create archive directly in iCloud
+                let archive = try Archive(url: destinationURL, accessMode: .create)
+                try archive.addEntry(with: "seed.json", relativeTo: tempDirectory)
+                try archive.addEntry(with: "pass.json", relativeTo: tempDirectory)
+                try archive.addEntry(with: "manifest.json", relativeTo: tempDirectory)
+
+                DispatchQueue.main.async {
+                    completion(.success(archive.url))
+                }
+
+            } catch let error as ICloudBackupError {
+                DispatchQueue.main.async {
+                    completion(.failure(error))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    completion(.failure(.failedToSave))
+                }
+            }
+        }
+    }
+
+    func deleteAllICloudBackups() {
+        guard let ubiquityURL = FileManager.default.url(forUbiquityContainerIdentifier: ubiquityContainerIdentifier)?.appendingPathComponent(fileStorageURL) else {
+            print("iCloud not available")
+            return
+        }
+
+        do {
+            let fileManager = FileManager.default
+            let contents = try fileManager.contentsOfDirectory(at: ubiquityURL, includingPropertiesForKeys: nil)
+
+            for fileURL in contents {
+                try fileManager.removeItem(at: fileURL)
+                print("Deleted: \(fileURL.lastPathComponent)")
+            }
+        } catch {
+            print("Failed to delete iCloud files: \(error)")
+        }
+    }
+    
+    func isBackupFileCreated() -> Bool {
+        guard let backupURL = getBackupFileURL(toICloud: true) else {
+            print("iCloud container URL not available")
+            return false
+        }
+        
+        let fileManager = FileManager.default
+        let exists = fileManager.fileExists(atPath: backupURL.path)
+        print("Checking backup file existence at iCloud path: \(backupURL.path) - Exists: \(exists)")
+        return exists
     }
 }

--- a/ConcordiumWallet/Features/SeedBackup/SeedPhraseEncryptionManager.swift
+++ b/ConcordiumWallet/Features/SeedBackup/SeedPhraseEncryptionManager.swift
@@ -1,0 +1,66 @@
+//
+//  SeedPhraseEncryptionManager.swift
+//  CryptoX
+//
+//  Created by Zhanna Komar on 09.06.2025.
+//  Copyright © 2025 pioneeringtechventures. All rights reserved.
+//
+
+import Foundation
+import CryptoKit
+
+struct SeedPhraseEncryptionManager {
+    
+    // Derive a symmetric key from password
+    private func deriveKey(from password: String, salt: Data) -> SymmetricKey {
+        let passwordData = Data(password.utf8)
+        let key = SymmetricKey(size: .bits256)
+        let derivedKey = HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: passwordData),
+            salt: salt,
+            info: Data("encryption-seed".utf8),
+            outputByteCount: 32
+        )
+        return derivedKey
+    }
+    
+    func encryptSeed(_ seedPhrase: String, password: String) throws -> Data {
+        let seedData = Data(seedPhrase.utf8)
+        let salt = Data((0..<16).map { _ in UInt8.random(in: 0...255) }) // random 16-byte salt
+        let nonce = AES.GCM.Nonce()
+        let key = deriveKey(from: password, salt: salt)
+        
+        let sealedBox = try AES.GCM.seal(seedData, using: key, nonce: nonce)
+        
+        // Combine salt + nonce + ciphertext + tag into single blob
+        var combined = Data()
+        combined.append(salt)
+        combined.append(contentsOf: nonce)
+        combined.append(sealedBox.ciphertext)
+        combined.append(sealedBox.tag)
+        
+        return combined
+    }
+    
+    func decryptSeed(_ encryptedData: Data, password: String) throws -> String {
+        // Extract salt (16 bytes), nonce (12 bytes), tag (16 bytes)
+        let salt = encryptedData.subdata(in: 0..<16)
+        let nonceData = encryptedData.subdata(in: 16..<28)
+        let tag = encryptedData.suffix(16)
+        let ciphertext = encryptedData.subdata(in: 28..<(encryptedData.count - 16))
+        
+        let key = deriveKey(from: password, salt: salt)
+        let nonce = try AES.GCM.Nonce(data: nonceData)
+        let sealedBox = try AES.GCM.SealedBox(nonce: nonce, ciphertext: ciphertext, tag: tag)
+        
+        let decryptedData = try AES.GCM.open(sealedBox, using: key)
+        guard let decryptedString = String(data: decryptedData, encoding: .utf8) else {
+            throw DecryptionError.invalidData
+        }
+        return decryptedString
+    }
+    
+    enum DecryptionError: Error {
+        case invalidData
+    }
+}

--- a/ConcordiumWallet/Features/SeedBackup/SeedPhraseEncryptionManager.swift
+++ b/ConcordiumWallet/Features/SeedBackup/SeedPhraseEncryptionManager.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 import CryptoKit
+import ZIPFoundation
 
 struct SeedPhraseEncryptionManager {
     
     // Derive a symmetric key from password
     private func deriveKey(from password: String, salt: Data) -> SymmetricKey {
         let passwordData = Data(password.utf8)
-        let key = SymmetricKey(size: .bits256)
         let derivedKey = HKDF<SHA256>.deriveKey(
             inputKeyMaterial: SymmetricKey(data: passwordData),
             salt: salt,
@@ -35,29 +35,68 @@ struct SeedPhraseEncryptionManager {
         // Combine salt + nonce + ciphertext + tag into single blob
         var combined = Data()
         combined.append(salt)
-        combined.append(contentsOf: nonce)
+        combined.append(contentsOf: nonce.withUnsafeBytes { Data($0) })
         combined.append(sealedBox.ciphertext)
         combined.append(sealedBox.tag)
+        
+        print("Salt: \(salt.base64EncodedString())")
+        print("Nonce: \(nonce.withUnsafeBytes { Data($0) }.base64EncodedString())")
+        print("Ciphertext: \(sealedBox.ciphertext.base64EncodedString())")
+        print("Tag: \(sealedBox.tag.base64EncodedString())")
         
         return combined
     }
     
-    func decryptSeed(_ encryptedData: Data, password: String) throws -> String {
+    func decryptSeed(_ encryptedData: Data, password: String? = nil) throws -> String {
         // Extract salt (16 bytes), nonce (12 bytes), tag (16 bytes)
         let salt = encryptedData.subdata(in: 0..<16)
         let nonceData = encryptedData.subdata(in: 16..<28)
         let tag = encryptedData.suffix(16)
         let ciphertext = encryptedData.subdata(in: 28..<(encryptedData.count - 16))
+
+        // Use a default password if none is provided
+        let actualPassword = password ?? "pwHash"
         
-        let key = deriveKey(from: password, salt: salt)
+        let key = deriveKey(from: actualPassword, salt: salt)
         let nonce = try AES.GCM.Nonce(data: nonceData)
         let sealedBox = try AES.GCM.SealedBox(nonce: nonce, ciphertext: ciphertext, tag: tag)
         
-        let decryptedData = try AES.GCM.open(sealedBox, using: key)
-        guard let decryptedString = String(data: decryptedData, encoding: .utf8) else {
-            throw DecryptionError.invalidData
+        print("Salt: \(salt.base64EncodedString())")
+        print("Nonce: \(nonceData.base64EncodedString())")
+        print("Ciphertext: \(ciphertext.base64EncodedString())")
+        print("Tag: \(tag.base64EncodedString())")
+        
+        do {
+            let decryptedData = try AES.GCM.open(sealedBox, using: key)
+            guard let decryptedString = String(data: decryptedData, encoding: .utf8) else {
+                throw DecryptionError.invalidData
+            }
+            return decryptedString
+        } catch {
+            print(error.localizedDescription)
         }
-        return decryptedString
+        return ""
+    }
+    
+    func decryptBackupFile(at url: URL) throws -> String {
+        // Unzip the file (you can use ZIPFoundation or similar)
+        let archive = try Archive(url: url, accessMode: .read)
+        
+        // Extract "seed.json" entry
+        guard let entry = archive["seed.json"] else {
+            throw NSError(domain: "Decryption", code: 1, userInfo: [NSLocalizedDescriptionKey: "seed.json not found"])
+        }
+        
+        var seedData = Data()
+        _ = try archive.extract(entry, consumer: { data in
+            seedData.append(data)
+        })
+
+        // Decrypt it
+        let manager = SeedPhraseEncryptionManager()
+        let decrypted = try manager.decryptSeed(seedData, password: "pwHash")
+
+        return decrypted
     }
     
     enum DecryptionError: Error {

--- a/ConcordiumWallet/Resources/en.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/en.lproj/Localizable.strings
@@ -1269,6 +1269,9 @@ Remember to restart your node with the validator keys.";
 "import.walletPrivateKey.title" = "Your wallet private key";
 "import.walletPrivateKey.subtitle" = "Please enter your wallet private key exactly how it was presented to you";
 
+"import.icloudBackup.title" = "Recover wallet using iCloud";
+"import.icloudBackup.subtitle" = "Please select the back up file to proceed with the recovery";
+
 "more.show.recovery.phrase.title" = "Show recovery phrase";
 "more.show.recovery.phrase.subtitle" = "Show you recovery seed phrase for this account";
 "more.remove.account.confirmation.title" = "Are you sure want to remove all account and related data?";
@@ -1469,3 +1472,6 @@ Remember to restart your node with the validator keys.";
 "primed.for.suspension.message" = "Your validation is primed for suspension";
 "suspended.message" =  "Your validation has been suspended";
 "multiple.accounts.suspended" = "Validation issues with several accounts";
+
+"seed.icloud.backup.success" = "Seed phrase was successfully backed up to iCloud";
+

--- a/ConcordiumWallet/Settings/AppSettings.swift
+++ b/ConcordiumWallet/Settings/AppSettings.swift
@@ -36,6 +36,7 @@ enum UserDefaultKeys: String {
     case isImportedFromFile
     
     case lastSelectedAccountAddress
+    case isOnboardingFinished
 }
 
 struct AppSettings {
@@ -187,6 +188,15 @@ extension AppSettings {
         }
         set {
             UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.lastSelectedAccountAddress.rawValue)
+        }
+    }
+    
+    static var isOnboardingFinished: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: UserDefaultKeys.isOnboardingFinished.rawValue)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.isOnboardingFinished.rawValue)
         }
     }
 }

--- a/CryptoX.xcodeproj/project.pbxproj
+++ b/CryptoX.xcodeproj/project.pbxproj
@@ -1694,6 +1694,23 @@
 		155EE23D2D7B4955005EF86E /* KeyboardAvoidingPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155EE23C2D7B4955005EF86E /* KeyboardAvoidingPadding.swift */; };
 		155EE23E2D7B4955005EF86E /* KeyboardAvoidingPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155EE23C2D7B4955005EF86E /* KeyboardAvoidingPadding.swift */; };
 		155EE23F2D7B4955005EF86E /* KeyboardAvoidingPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155EE23C2D7B4955005EF86E /* KeyboardAvoidingPadding.swift */; };
+		1571AC322DF6BFBD006A6431 /* SeedPhraseBackupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC312DF6BFBD006A6431 /* SeedPhraseBackupManager.swift */; };
+		1571AC332DF6BFBD006A6431 /* SeedPhraseBackupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC312DF6BFBD006A6431 /* SeedPhraseBackupManager.swift */; };
+		1571AC342DF6BFBD006A6431 /* SeedPhraseBackupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC312DF6BFBD006A6431 /* SeedPhraseBackupManager.swift */; };
+		1571AC372DF6C147006A6431 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 1571AC362DF6C147006A6431 /* ZIPFoundation */; };
+		1571AC392DF6C14E006A6431 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 1571AC382DF6C14E006A6431 /* ZIPFoundation */; };
+		1571AC3B2DF6C5E6006A6431 /* BackupExportFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC3A2DF6C5E6006A6431 /* BackupExportFileView.swift */; };
+		1571AC3C2DF6C5E6006A6431 /* BackupExportFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC3A2DF6C5E6006A6431 /* BackupExportFileView.swift */; };
+		1571AC3D2DF6C5E6006A6431 /* BackupExportFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC3A2DF6C5E6006A6431 /* BackupExportFileView.swift */; };
+		1571AC3F2DF6DCCC006A6431 /* SeedPhraseEncryptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC3E2DF6DCCC006A6431 /* SeedPhraseEncryptionManager.swift */; };
+		1571AC402DF6DCCC006A6431 /* SeedPhraseEncryptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC3E2DF6DCCC006A6431 /* SeedPhraseEncryptionManager.swift */; };
+		1571AC412DF6DCCC006A6431 /* SeedPhraseEncryptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC3E2DF6DCCC006A6431 /* SeedPhraseEncryptionManager.swift */; };
+		1571AC432DF6E185006A6431 /* BackupFileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC422DF6E185006A6431 /* BackupFileViewModel.swift */; };
+		1571AC442DF6E185006A6431 /* BackupFileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC422DF6E185006A6431 /* BackupFileViewModel.swift */; };
+		1571AC452DF6E185006A6431 /* BackupFileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC422DF6E185006A6431 /* BackupFileViewModel.swift */; };
+		1571AC472DF6E1FB006A6431 /* ImportSeedPhraseBackupFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC462DF6E1FB006A6431 /* ImportSeedPhraseBackupFileView.swift */; };
+		1571AC482DF6E1FB006A6431 /* ImportSeedPhraseBackupFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC462DF6E1FB006A6431 /* ImportSeedPhraseBackupFileView.swift */; };
+		1571AC492DF6E1FB006A6431 /* ImportSeedPhraseBackupFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1571AC462DF6E1FB006A6431 /* ImportSeedPhraseBackupFileView.swift */; };
 		1575862E2CA2CA4D00205A6E /* IdentifiableString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1575862D2CA2CA4D00205A6E /* IdentifiableString.swift */; };
 		1575862F2CA2CA4D00205A6E /* IdentifiableString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1575862D2CA2CA4D00205A6E /* IdentifiableString.swift */; };
 		157586302CA2CA4D00205A6E /* IdentifiableString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1575862D2CA2CA4D00205A6E /* IdentifiableString.swift */; };
@@ -2979,6 +2996,11 @@
 		1557CCA82C8AF779008ABF67 /* AllowNotificationsPopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllowNotificationsPopup.swift; sourceTree = "<group>"; };
 		155EE1F02D7B3BFC005EF86E /* AlertModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertModifier.swift; sourceTree = "<group>"; };
 		155EE23C2D7B4955005EF86E /* KeyboardAvoidingPadding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardAvoidingPadding.swift; sourceTree = "<group>"; };
+		1571AC312DF6BFBD006A6431 /* SeedPhraseBackupManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedPhraseBackupManager.swift; sourceTree = "<group>"; };
+		1571AC3A2DF6C5E6006A6431 /* BackupExportFileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupExportFileView.swift; sourceTree = "<group>"; };
+		1571AC3E2DF6DCCC006A6431 /* SeedPhraseEncryptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedPhraseEncryptionManager.swift; sourceTree = "<group>"; };
+		1571AC422DF6E185006A6431 /* BackupFileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupFileViewModel.swift; sourceTree = "<group>"; };
+		1571AC462DF6E1FB006A6431 /* ImportSeedPhraseBackupFileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportSeedPhraseBackupFileView.swift; sourceTree = "<group>"; };
 		1575862D2CA2CA4D00205A6E /* IdentifiableString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableString.swift; sourceTree = "<group>"; };
 		157586312CA43E5500205A6E /* CooldownEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CooldownEntity.swift; sourceTree = "<group>"; };
 		157586352CA441DC00205A6E /* AccountCooldown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCooldown.swift; sourceTree = "<group>"; };
@@ -3343,6 +3365,7 @@
 				08C169152BB7396200E61326 /* JDStatusBarNotification in Frameworks */,
 				08C169172BB7396200E61326 /* SDWebImageSVGCoder in Frameworks */,
 				50E0D1652D2ECDDD00853594 /* Starscream in Frameworks */,
+				1571AC372DF6C147006A6431 /* ZIPFoundation in Frameworks */,
 				08C169182BB7396200E61326 /* ConcordiumWalletCrypto in Frameworks */,
 				50E0D1672D2ECE1600853594 /* ReownWalletKit in Frameworks */,
 				15339E6D2DB8FF1F003D64D1 /* FirebaseAnalytics in Frameworks */,
@@ -3365,6 +3388,7 @@
 				083505072A9F4F14000D5175 /* SDWebImageSVGCoder in Frameworks */,
 				50E0D1692D35466100853594 /* Starscream in Frameworks */,
 				509A56392CB43540005EA908 /* RealmSwift in Frameworks */,
+				1571AC392DF6C14E006A6431 /* ZIPFoundation in Frameworks */,
 				1558E89B2CFA2BBF00004E71 /* DotLottie in Frameworks */,
 				5044206D2D706BE400AF1CF9 /* ConcordiumWalletCrypto in Frameworks */,
 				15339E712DB8FF2E003D64D1 /* FirebaseAnalytics in Frameworks */,
@@ -3634,6 +3658,7 @@
 		088FEC682A01483D00042957 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				1571AC302DF6BFA4006A6431 /* SeedBackup */,
 				15B498D62D5E30EE001B4F65 /* NewStake */,
 				509749DF2C3E862500D28D6B /* NewsFeed */,
 				509749CE2C3C0D2B00D28D6B /* OnrampFlow */,
@@ -4835,6 +4860,18 @@
 			path = Firebase;
 			sourceTree = "<group>";
 		};
+		1571AC302DF6BFA4006A6431 /* SeedBackup */ = {
+			isa = PBXGroup;
+			children = (
+				1571AC312DF6BFBD006A6431 /* SeedPhraseBackupManager.swift */,
+				1571AC3E2DF6DCCC006A6431 /* SeedPhraseEncryptionManager.swift */,
+				1571AC3A2DF6C5E6006A6431 /* BackupExportFileView.swift */,
+				1571AC422DF6E185006A6431 /* BackupFileViewModel.swift */,
+				1571AC462DF6E1FB006A6431 /* ImportSeedPhraseBackupFileView.swift */,
+			);
+			path = SeedBackup;
+			sourceTree = "<group>";
+		};
 		1580EBDC2D4A38190051C55D /* Navigation */ = {
 			isa = PBXGroup;
 			children = (
@@ -5887,6 +5924,7 @@
 				50E0D1642D2ECDDD00853594 /* Starscream */,
 				50E0D1662D2ECE1600853594 /* ReownWalletKit */,
 				15339E6C2DB8FF1F003D64D1 /* FirebaseAnalytics */,
+				1571AC362DF6C147006A6431 /* ZIPFoundation */,
 			);
 			productName = ConcordiumWallet;
 			productReference = 08C169C22BB7396200E61326 /* ProdTestNet.app */;
@@ -5930,6 +5968,7 @@
 				50E0D16A2D35466600853594 /* ReownWalletKit */,
 				5044206C2D706BE400AF1CF9 /* ConcordiumWalletCrypto */,
 				15339E702DB8FF2E003D64D1 /* FirebaseAnalytics */,
+				1571AC382DF6C14E006A6431 /* ZIPFoundation */,
 			);
 			productName = ConcordiumWallet;
 			productReference = 7F85B8CC246A9AB600ED09B8 /* ProdMainNet.app */;
@@ -6040,6 +6079,7 @@
 				501F5AE02D2ECA1F00C55008 /* XCRemoteSwiftPackageReference "reown-swift" */,
 				50E0D1632D2ECDDD00853594 /* XCRemoteSwiftPackageReference "Starscream" */,
 				504420692D706BD300AF1CF9 /* XCRemoteSwiftPackageReference "concordium-wallet-crypto-swift" */,
+				1571AC352DF6C136006A6431 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 			);
 			productRefGroup = 7FF07A6A23EADB1200F1FC04 /* Products */;
 			projectDirPath = "";
@@ -6438,6 +6478,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08C166742BB7396200E61326 /* Credential.swift in Sources */,
+				1571AC3F2DF6DCCC006A6431 /* SeedPhraseEncryptionManager.swift in Sources */,
 				08C166752BB7396200E61326 /* AccountAddressQRViewController.swift in Sources */,
 				08C166762BB7396200E61326 /* IPInfo.swift in Sources */,
 				08C169D62BC0397600E61326 /* SignMessagePayloadToJsonInput.swift in Sources */,
@@ -6491,6 +6532,7 @@
 				08C1669E2BB7396200E61326 /* IdentityBaseInfoWidgetPresenter.swift in Sources */,
 				08C1669F2BB7396200E61326 /* PasscodeInputModifier.swift in Sources */,
 				08C166A02BB7396200E61326 /* URL+queryParameters.swift in Sources */,
+				1571AC442DF6E185006A6431 /* BackupFileViewModel.swift in Sources */,
 				08C166A12BB7396200E61326 /* CreateNicknameViewController.swift in Sources */,
 				08C166A22BB7396200E61326 /* RewardParameters.swift in Sources */,
 				08C166A32BB7396200E61326 /* IdentityCard.swift in Sources */,
@@ -6621,6 +6663,7 @@
 				08C1672B2BB7396200E61326 /* NFTTokensStatusView.swift in Sources */,
 				08C1672C2BB7396200E61326 /* IDRequestV1.swift in Sources */,
 				08C1672E2BB7396200E61326 /* RecoveryIdentityResponse.swift in Sources */,
+				1571AC3B2DF6C5E6006A6431 /* BackupExportFileView.swift in Sources */,
 				08C1672F2BB7396200E61326 /* CreateSeedIdentityViewModel.swift in Sources */,
 				08C169C82BBFE1C900E61326 /* AnyPublisher+Extentions.swift in Sources */,
 				08E472A92BCEE85C004F0088 /* SignMessageRequestModel.swift in Sources */,
@@ -6732,6 +6775,7 @@
 				08C167962BB7396200E61326 /* SeedIdentitiesCoordinator.swift in Sources */,
 				08C167972BB7396200E61326 /* IPArDatum.swift in Sources */,
 				08C167992BB7396200E61326 /* CurrentPaydayStatus.swift in Sources */,
+				1571AC472DF6E1FB006A6431 /* ImportSeedPhraseBackupFileView.swift in Sources */,
 				08C1679A2BB7396200E61326 /* QRTransactionBuyView.swift in Sources */,
 				08C1679B2BB7396200E61326 /* ContactSupportButtonWidgetPresenter.swift in Sources */,
 				08C1679C2BB7396200E61326 /* RecoveryPhraseRecoverCompletePresenter.swift in Sources */,
@@ -7017,6 +7061,7 @@
 				08C168B32BB7396200E61326 /* SupportMailProtocol.swift in Sources */,
 				08C168B42BB7396200E61326 /* Transaction.swift in Sources */,
 				08C168B62BB7396200E61326 /* SubmissionStatusService.swift in Sources */,
+				1571AC332DF6BFBD006A6431 /* SeedPhraseBackupManager.swift in Sources */,
 				08C168B72BB7396200E61326 /* Data+Additions.swift in Sources */,
 				08C168B82BB7396200E61326 /* ScanAddressQRViewController.swift in Sources */,
 				08C168B92BB7396200E61326 /* ScanAddressQRPresenter.swift in Sources */,
@@ -7119,6 +7164,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08A0461429FA99D300DACE1F /* Credential.swift in Sources */,
+				1571AC412DF6DCCC006A6431 /* SeedPhraseEncryptionManager.swift in Sources */,
 				088FEDAB2A01675600042957 /* AccountAddressQRViewController.swift in Sources */,
 				08A045FA29FA99D200DACE1F /* IPInfo.swift in Sources */,
 				08C169D52BC0397600E61326 /* SignMessagePayloadToJsonInput.swift in Sources */,
@@ -7172,6 +7218,7 @@
 				088FEF792A0270B000042957 /* IdentityBaseInfoWidgetPresenter.swift in Sources */,
 				08D103E52B56DF380057E844 /* PasscodeInputModifier.swift in Sources */,
 				7F85B7DC246A9AB600ED09B8 /* URL+queryParameters.swift in Sources */,
+				1571AC432DF6E185006A6431 /* BackupFileViewModel.swift in Sources */,
 				088FEEAB2A026B7300042957 /* CreateNicknameViewController.swift in Sources */,
 				08A0461C29FA99D300DACE1F /* RewardParameters.swift in Sources */,
 				088FEFC52A02718F00042957 /* IdentityCard.swift in Sources */,
@@ -7302,6 +7349,7 @@
 				D52D4F8A2919D75F00C9A815 /* NFTTokensStatusView.swift in Sources */,
 				08A0449629FA987800DACE1F /* IDRequestV1.swift in Sources */,
 				08A0449029FA987800DACE1F /* RecoveryIdentityResponse.swift in Sources */,
+				1571AC3C2DF6C5E6006A6431 /* BackupExportFileView.swift in Sources */,
 				088FEFE52A0271C000042957 /* CreateSeedIdentityViewModel.swift in Sources */,
 				08C169C72BBFE1C900E61326 /* AnyPublisher+Extentions.swift in Sources */,
 				08E472A82BCEE85C004F0088 /* SignMessageRequestModel.swift in Sources */,
@@ -7413,6 +7461,7 @@
 				088FF00F2A0271F700042957 /* SeedIdentitiesCoordinator.swift in Sources */,
 				08A045ED29FA99D200DACE1F /* IPArDatum.swift in Sources */,
 				08A0460129FA99D200DACE1F /* CurrentPaydayStatus.swift in Sources */,
+				1571AC482DF6E1FB006A6431 /* ImportSeedPhraseBackupFileView.swift in Sources */,
 				D5B393F027197CD30094A9F5 /* QRTransactionBuyView.swift in Sources */,
 				088FEF7B2A0270B000042957 /* ContactSupportButtonWidgetPresenter.swift in Sources */,
 				088FF0AD2A02845300042957 /* RecoveryPhraseRecoverCompletePresenter.swift in Sources */,
@@ -7698,6 +7747,7 @@
 				D5E29758276C8D0F000DB102 /* SupportMailProtocol.swift in Sources */,
 				08A0461E29FA99D300DACE1F /* Transaction.swift in Sources */,
 				7F85B8B4246A9AB600ED09B8 /* SubmissionStatusService.swift in Sources */,
+				1571AC322DF6BFBD006A6431 /* SeedPhraseBackupManager.swift in Sources */,
 				D5B47101278DC1A200781EE8 /* Data+Additions.swift in Sources */,
 				088FF24F2A02A9A200042957 /* ScanAddressQRViewController.swift in Sources */,
 				088FF24E2A02A9A200042957 /* ScanAddressQRPresenter.swift in Sources */,
@@ -7800,6 +7850,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D5962CD9272170F800A757A5 /* TransactionDetailsView.swift in Sources */,
+				1571AC402DF6DCCC006A6431 /* SeedPhraseEncryptionManager.swift in Sources */,
 				08A0457C29FA99D100DACE1F /* Credential.swift in Sources */,
 				088FEDA52A01675500042957 /* AccountAddressQRViewController.swift in Sources */,
 				08C169D42BC0397600E61326 /* SignMessagePayloadToJsonInput.swift in Sources */,
@@ -7853,6 +7904,7 @@
 				D589F19F2794B5ED003F2FBB /* TransferFiltersEntity.swift in Sources */,
 				08D103E42B56DF380057E844 /* PasscodeInputModifier.swift in Sources */,
 				08A044A129FA98F300DACE1F /* ChainParametersEntity.swift in Sources */,
+				1571AC452DF6E185006A6431 /* BackupFileViewModel.swift in Sources */,
 				088FEF512A0270AF00042957 /* IdentityBaseInfoWidgetPresenter.swift in Sources */,
 				D589F1F32794B5ED003F2FBB /* KeyList.swift in Sources */,
 				C93A752F24464813003FDBE2 /* URL+queryParameters.swift in Sources */,
@@ -7983,6 +8035,7 @@
 				08A0447A29FA987700DACE1F /* IDRequestV1.swift in Sources */,
 				08A0447429FA987700DACE1F /* RecoveryIdentityResponse.swift in Sources */,
 				644BB67425DFB4220086ED48 /* main.swift in Sources */,
+				1571AC3D2DF6C5E6006A6431 /* BackupExportFileView.swift in Sources */,
 				08A0454329FA99D100DACE1F /* AttributeList.swift in Sources */,
 				D589F3172794B678003F2FBB /* ErrorMapper.swift in Sources */,
 				08C169C62BBFE1C900E61326 /* AnyPublisher+Extentions.swift in Sources */,
@@ -8094,6 +8147,7 @@
 				1580EBF52D4A41240051C55D /* ChooseTokenView.swift in Sources */,
 				157586322CA43E5500205A6E /* CooldownEntity.swift in Sources */,
 				08A0456929FA99D100DACE1F /* CurrentPaydayStatus.swift in Sources */,
+				1571AC492DF6E1FB006A6431 /* ImportSeedPhraseBackupFileView.swift in Sources */,
 				FA7C079F26C5AFF3008714CB /* ConnectionRequestVC.swift in Sources */,
 				088FF00B2A0271F600042957 /* SeedIdentitiesCoordinator.swift in Sources */,
 				7FF07AC423EADBB100F1FC04 /* UITableView+scroll.swift in Sources */,
@@ -8379,6 +8433,7 @@
 				19C2E12895547B11D377B76F /* AccountsService.swift in Sources */,
 				088FF24B2A02A9A100042957 /* ScanAddressQRViewController.swift in Sources */,
 				088FF24A2A02A9A100042957 /* ScanAddressQRPresenter.swift in Sources */,
+				1571AC342DF6BFBD006A6431 /* SeedPhraseBackupManager.swift in Sources */,
 				088FF1C02A02A70700042957 /* ExportPresenter.swift in Sources */,
 				08DB5E1F2BC6C2B900C29663 /* DelegationDataHandler.swift in Sources */,
 				088FF1E62A02A73C00042957 /* UpdatePasswordPresenter.swift in Sources */,
@@ -9098,6 +9153,14 @@
 				kind = branch;
 			};
 		};
+		1571AC352DF6C136006A6431 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/weichsel/ZIPFoundation";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.19;
+			};
+		};
 		501F5AE02D2ECA1F00C55008 /* XCRemoteSwiftPackageReference "reown-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/reown-com/reown-swift";
@@ -9262,6 +9325,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 1558E8972CFA2BA700004E71 /* XCRemoteSwiftPackageReference "dotlottie-ios" */;
 			productName = DotLottie;
+		};
+		1571AC362DF6C147006A6431 /* ZIPFoundation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1571AC352DF6C136006A6431 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+			productName = ZIPFoundation;
+		};
+		1571AC382DF6C14E006A6431 /* ZIPFoundation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1571AC352DF6C136006A6431 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+			productName = ZIPFoundation;
 		};
 		5044206A2D706BDE00AF1CF9 /* ConcordiumWalletCrypto */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CryptoX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CryptoX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c674f6f4666d8581fc5a1d76fcf285ee329038c6015f853e628fe2da7e2a94d8",
+  "originHash" : "875eb59d06ccd21360debbf3d0f5ba3c06e49d82cb68da712cf6ffb9a537a36d",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -296,6 +296,15 @@
       "state" : {
         "revision" : "4aa89e682f8d7ab1515d85d0797f0d25306bb56a",
         "version" : "1.0.5"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation",
+      "state" : {
+        "revision" : "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
+        "version" : "0.9.19"
       }
     }
   ],

--- a/ProdTestNet.entitlements
+++ b/ProdTestNet.entitlements
@@ -8,6 +8,18 @@
 	<array>
 		<string>applinks:cryptox</string>
 	</array>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.pioneeringtechventures.cryptox</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
+	<key>com.apple.developer.ubiquity-container-identifiers</key>
+	<array>
+		<string>iCloud.com.pioneeringtechventures.cryptox</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.reown.testnet</string>


### PR DESCRIPTION
## Purpose

Adding a feature that is an alternative way to store the seed phrase, encrypted in the user's iCloud drive (not a whole wallet backup). The feature is set to be part of the existing/created account (not part of the new wallet setup flow) on the Settings screen. The user needs to be able to manually back up their seedphrase.

## Changes

- Add option in the Reveal seed phrase view to backup it to the iCloud drive
- Add possibility to select the backup file to recover accounts.

https://github.com/user-attachments/assets/e8399876-b44a-47a3-8086-f69a84992a56

