### PR TITLE
WAL-1009 Remove list of exchanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## UNRELEASED
 - Fixes an issue with social links
 
+
 ## [Released 3.3.3]
 - Fixed an issue with the keyboard on the Earn screen
 - Fixed an issue with the amount input field on the Earn screen
 - Added SwiftSDK and replaced concordium-wallet-crypto-swift with a local package
+- On the Buy screen, exchange sections are replaced with an external link
 
 ## [Released 3.3.2] Max 13, 2025
 

--- a/ConcordiumWallet/Features/OnrampFlow/CCDOnrampView.swift
+++ b/ConcordiumWallet/Features/OnrampFlow/CCDOnrampView.swift
@@ -59,7 +59,7 @@ struct CCDOnrampView: View {
                     }
                     
                     Button {
-                        openURL(URL(string: "https://concordium.com/ccd-wallet")!)
+                        openURL(AppConstants.Support.ccdsList)
                     } label: {
                         Group {
                             Text("List of supported exchanges can be found at")

--- a/ConcordiumWallet/Features/OnrampFlow/CCDOnrampView.swift
+++ b/ConcordiumWallet/Features/OnrampFlow/CCDOnrampView.swift
@@ -14,7 +14,7 @@ struct CCDOnrampView: View {
     let dependencyProvider: AccountsFlowCoordinatorDependencyProvider
     
     @State var isAccountsPickerShown: CCDOnrampViewDataProvider.DataProvider?
-    
+
     var body: some View {
         NavigationView {
             ScrollViewReader(content: { proxy in
@@ -57,6 +57,25 @@ struct CCDOnrampView: View {
                                 .font(.satoshi(size: 12, weight: .regular))
                         }
                     }
+                    
+                    Button {
+                        openURL(URL(string: "https://concordium.com/ccd-wallet")!)
+                    } label: {
+                        Group {
+                            Text("List of supported exchanges can be found at")
+                                .font(.satoshi(size: 12, weight: .regular))
+                              .foregroundColor(Color(red: 0.84, green: 0.89, blue: 0.94))
+                            + Text(" concordium.com/ccd-wallet")
+                                .underline()
+                                .font(.satoshi(size: 12, weight: .regular))
+                                .foregroundColor(Color(red: 0.84, green: 0.89, blue: 0.94))
+                        }
+                        .multilineTextAlignment(.center)
+                    }
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
+                    .padding(.top, 40)
+                    .padding(.horizontal, 32)
                     
                     ListFooter()
                         .listRowSeparator(.hidden)

--- a/ConcordiumWallet/Features/OnrampFlow/CCDOnrampViewDataProvider.swift
+++ b/ConcordiumWallet/Features/OnrampFlow/CCDOnrampViewDataProvider.swift
@@ -29,14 +29,10 @@ final class CCDOnrampViewDataProvider {
 #if MAINNET
         [
             DataProvidersSection(title: "Payment Gateway", providers: CCDOnrampViewDataProvider.swipelux),
-            DataProvidersSection(title: "CEX", providers: CCDOnrampViewDataProvider.cex),
-            DataProvidersSection(title: "DEX", providers: [CCDOnrampViewDataProvider.dex]),
         ]
 #else
         [
             DataProvidersSection(title: "Payment Gateway", providers: CCDOnrampViewDataProvider.swipelux),
-            DataProvidersSection(title: "CEX", providers: CCDOnrampViewDataProvider.cex),
-            DataProvidersSection(title: "DEX", providers: [CCDOnrampViewDataProvider.dex]),
             DataProvidersSection(title: "Testnet", providers: [CCDOnrampViewDataProvider.testnet]),
         ]
 #endif
@@ -67,67 +63,6 @@ final class CCDOnrampViewDataProvider {
             icon: URL(string: "https://em-content.zobj.net/source/apple/391/smiling-face-with-sunglasses_1f60e.png")!,
             isPaymentProvider: true
         )
-    }
-    
-    static var cex: [DataProvider] {
-        [
-            DataProvider(
-                title: "KuCoin",
-                url: URL(string: "https://www.kucoin.com/")!,
-                icon: URL(string: "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/64f0d1d17b59787f0d1b3740_logo-favicon-kucoin.png")!
-            ),
-            DataProvider(
-                title: "Bitfinex",
-                url: URL(string: "https://trading.bitfinex.com/t/CCD:USD?type=exchange")!,
-                icon: URL(string: "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/64f0d15bd065ec0e03a32ac5_bitfinex.png")!
-            ),
-            DataProvider(
-                title: "Lets Exchange",
-                url: URL(string: "https://letsexchange.io/")!,
-                icon: URL(string: "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/64fed810c7dd2cfc068c17cf_1680692222678%20(1).jpg")!
-            ),
-            DataProvider(
-                title: "AscendEX (BitMax)",
-                url: URL(string: "https://ascendex.com/en/cashtrade-spottrading/usdt/ccd")!,
-                icon: URL(string: "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/64f0d273cc264cf97db45e72_logo-favicon-ascendex.png")!
-            ),
-            DataProvider(
-                title: "MEXC",
-                url: URL(string: "https://www.mexc.com/")!,
-                icon: URL(string: "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/64f0d2446607fca14ba4af27_logo-favicon-mexc.png")!
-            ),
-            DataProvider(
-                title: "Bit2Me Pro",
-                url: URL(string: "https://bit2me.com/price/concordium")!,
-                icon: URL(string: "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/64f0d2d9a6d5f9d1cca6dfe6_logo-favicon-bit2me.png")!
-            ),
-            DataProvider(
-                title: "LCX",
-                url: URL(string: "https://exchange.lcx.com/")!,
-                icon: URL(string: "https://assets-global.website-files.com/64f060f3fc95f9d2081781db/660ef2975d8736c5529f54b9_LCX.jpg")!
-            ),
-            DataProvider(
-                title: "Gate.io",
-                url: URL(string: "https://www.gate.io/trade/CCD_USDT")!,
-                icon: Bundle.main.url(forResource: "Gate_io", withExtension: "png")!
-            )
-        ]
-    }
-    
-    static var dex: DataProvider {
-        #if MAINNET
-            DataProvider(
-                title: "Concordex",
-                url: URL(string: "https://app.concordex.io/trade?mode=simple")!,
-                icon: URL(string: "https://cdn.prod.website-files.com/64f060f3fc95f9d2081781db/64f0d420d065ec0e03a694b9_logo-favicon-concordex.png")!
-            )
-        #else
-            DataProvider(
-                title: "Concordex Testnet",
-                url: URL(string: "https://testnet.concordex.io/trade?mode=simple")!,
-                icon: URL(string: "https://cdn.prod.website-files.com/64f060f3fc95f9d2081781db/64f0d420d065ec0e03a694b9_logo-favicon-concordex.png")!
-            )
-        #endif
     }
     
     private static func generateSwipeluxURL(

--- a/ioscommon/Base/AppConstants.swift
+++ b/ioscommon/Base/AppConstants.swift
@@ -3,6 +3,7 @@ import Foundation
 struct AppConstants {
     struct Support {
         static let concordiumSupportMail: String = Bundle.main.object(forInfoDictionaryKey: "Concordium Support Mail") as? String ?? ""
+        static let ccdsList: URL = URL(string: "https://concordium.com/ccd-wallet")!
     }
     
     struct TermsAndConditions {


### PR DESCRIPTION
## Purpose

To streamline the UI/UX on both platforms, we need to remove the list of currently supported exchanges within the CryptoX

Instead, we would show a message linking users to our website: “List of supported exchanges can be found at concordium.com/ccd-wallet

## Changes

- On the Buy screen, exchange sections are replaced with an external link
