### PR TITLE
Fix Deep Link Handling

### DIFF
--- a/ConcordiumWallet/AppDelegate.swift
+++ b/ConcordiumWallet/AppDelegate.swift
@@ -116,10 +116,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 appCoordinator.mode = .deepLink(url: url)
                 appCoordinator.handle(url)
             }
-        } else {
-            // importing file
+        } else if let scheme = url.scheme, scheme.localizedCaseInsensitiveCompare("file") == .orderedSame {
+            // importing file - only handle file:// URLs
             appCoordinator.importWallet(from: url)
         }
+        // Removed the fallback else case to prevent handling regular deep links as file imports
         
         return true
     }


### PR DESCRIPTION
Now app opens import from file flow while opening via raw schema, lie: `cryptoxtestnet://` which is wrong behaviour

- fixed app opened via chema