### PR TITLE
fix displaying allow/deny list / show token ID instead of name

### DIFF
--- a/ConcordiumWallet/Design/Components/PLTTokenTags.swift
+++ b/ConcordiumWallet/Design/Components/PLTTokenTags.swift
@@ -12,6 +12,7 @@ enum PLTTokenState: String {
     case allowList = "Account is on the allow list"
     case notOnAllowList = "Account not on the allow list"
     case denyList = "Account on the deny list"
+    case undefined
 }
 
 struct PLTTokenTags: View {
@@ -51,16 +52,17 @@ struct PLTTokenTags: View {
 }
 
 final class PLTTokenTagViewModel: ObservableObject {
-    let allowList: Bool
-    let denyList: Bool
+    let allowList: Bool?
+    let denyList: Bool?
 
     var pltState: PLTTokenState {
-        if denyList { return .denyList}
-        if allowList { return .allowList }
-        return .notOnAllowList
+        if let denyList, denyList { return .denyList}
+        if let allowList, allowList { return .allowList }
+        if let allowList, !allowList { return .notOnAllowList }
+        return .undefined
     }
     
-    init(allowList: Bool, denyList: Bool) {
+    init(allowList: Bool?, denyList: Bool?) {
         self.allowList = allowList
         self.denyList = denyList
     }
@@ -74,6 +76,8 @@ final class PLTTokenTagViewModel: ObservableObject {
             return "circled-check-done"
         case .notOnAllowList, .denyList:
             return "circled-x-block-deny"
+        default:
+            return ""
         }
     }
     
@@ -88,6 +92,8 @@ final class PLTTokenTagViewModel: ObservableObject {
             return (Color.Status.infoOrange, .warningTertiary, .warningSecondary)
         case .denyList:
             return (.errorPrimary, .errorTertiary, .errorSecondary)
+        default:
+            return (.clear, .clear, .clear)
         }
     }
 

--- a/ConcordiumWallet/Features/CIS2TokenSupport/ImportToken/Models/ImportTokenViewModel.swift
+++ b/ConcordiumWallet/Features/CIS2TokenSupport/ImportToken/Models/ImportTokenViewModel.swift
@@ -120,7 +120,7 @@ final class ImportTokenViewModel: ObservableObject {
             guard !CoreDataPLTStore.shared.isPLTTokenSaved(tokenId: pltToken.tokenID, for: account.address) else {
                 return
             }
-            let tokenAccountState = TokenAccountState(balance: TokenBalance(decimals: pltToken.tokenState.decimals, value: ""), state: TokenBalanceState(denyList: nil))
+            let tokenAccountState = TokenAccountState(balance: TokenBalance(decimals: pltToken.tokenState.decimals, value: ""), state: TokenBalanceState(denyList: nil, allowList: nil))
             let accountPLTToken = AccountPLTToken(token: pltToken, tokenAccountState: tokenAccountState)
             CoreDataPLTStore.shared.saveTokens([accountPLTToken], for: account.address)
                 .receive(on: DispatchQueue.main)

--- a/ConcordiumWallet/Features/CIS2TokenSupport/ImportToken/Views/TokenView.swift
+++ b/ConcordiumWallet/Features/CIS2TokenSupport/ImportToken/Views/TokenView.swift
@@ -61,7 +61,7 @@ struct TokenView: View {
             return TokenListCellData(
                 id: pltToken.id,
                 icon: AnyView(Image("placeholder-crypto-token").resizable().clipShape(Circle())),
-                title: pltToken.tokenState.moduleState.name,
+                title: pltToken.tokenID,
                 subtitle: "PLT",
                 amount: TokenFormatter.formatPLTTokenAmount(amount: pltToken.tokenState.totalSupply.value),
                 secondaryAmount: nil,

--- a/ConcordiumWallet/Features/NewAccountFlow/AccountTokenListView.swift
+++ b/ConcordiumWallet/Features/NewAccountFlow/AccountTokenListView.swift
@@ -115,12 +115,12 @@ struct AccountTokenListView: View {
             return TokenListCellData(
                 id: account.id,
                 icon: AnyView(Image("placeholder-crypto-token").resizable().clipShape(Circle())),
-                title: token.token.tokenState.moduleState.name,
+                title: token.token.tokenID,
                 subtitle: "PLT",
                 amount: amount,
                 secondaryAmount: nil,
                 tokenImage: .plt,
-                showDenyIcon: token.token.tokenState.moduleState.denyList || !token.token.tokenState.moduleState.allowList,
+                showDenyIcon: token.tokenAccountState.state.denyList ?? false,
                 isCCD: false
             )
         }
@@ -245,7 +245,7 @@ final class AccountDetailViewModel: ObservableObject, Hashable, Equatable {
                 let tokenBalance = pltTokenBalances.first(where: { $0.key == token.tokenId })
                 let fallback = TokenAccountState(
                     balance: TokenBalance(decimals: Int(token.tokenState.decimals), value: "0"),
-                    state: TokenBalanceState(denyList: nil)
+                    state: TokenBalanceState(denyList: nil, allowList: nil)
                 )
 
                 guard let accountPLTToken = token.asPLTToken() else { return nil }

--- a/ConcordiumWallet/Features/NewAccountFlow/TokenDetailsView.swift
+++ b/ConcordiumWallet/Features/NewAccountFlow/TokenDetailsView.swift
@@ -69,7 +69,7 @@ struct TokenDetailsView: View {
                             .frame(maxWidth: .infinity, alignment: .topLeading)
                     case .plt(let pltToken, _):
                         titleSection(token: token)
-                        PLTTokenTags(viewModel: PLTTokenTagViewModel(allowList: pltToken.token.tokenState.moduleState.allowList, denyList: pltToken.token.tokenState.moduleState.denyList))
+                        PLTTokenTags(viewModel: PLTTokenTagViewModel(allowList: pltToken.tokenAccountState.state.allowList, denyList: pltToken.tokenAccountState.state.denyList))
                             .padding(.bottom, 4)
                         descriptionSection(decimals: pltToken.tokenAccountState.balance.decimals, decription: pltToken.token.tokenState.moduleState.metadata.url)
                     }

--- a/ConcordiumWallet/Features/PLTTokenSupport/CoreData/CoreDataPLTStore.swift
+++ b/ConcordiumWallet/Features/PLTTokenSupport/CoreData/CoreDataPLTStore.swift
@@ -160,8 +160,18 @@ final class CoreDataPLTStore {
         balance.decimals = Int16(model.tokenAccountState.balance.decimals)
         balance.value = model.tokenAccountState.balance.value
 
-        let state = StateEntity(context: context)
-        state.denyList = model.tokenAccountState.state.denyList ?? false
+        var state: StateEntity?
+        if model.tokenAccountState.state.denyList != nil ||
+            model.tokenAccountState.state.allowList != nil {
+            
+            state = StateEntity(context: context)
+            if let denyList = model.tokenAccountState.state.denyList {
+                state?.denyList = denyList
+            }
+            if let allowList = model.tokenAccountState.state.allowList {
+                state?.allowList = allowList
+            }
+        }
 
         let accountState = TokenAccountStateEntity(context: context)
         accountState.balance = balance

--- a/ConcordiumWallet/Features/PLTTokenSupport/CoreData/StateEntity+CoreDataProperties.swift
+++ b/ConcordiumWallet/Features/PLTTokenSupport/CoreData/StateEntity+CoreDataProperties.swift
@@ -18,6 +18,7 @@ extension StateEntity {
     }
 
     @NSManaged public var denyList: Bool
+    @NSManaged public var allowList: Bool
 
 }
 

--- a/ConcordiumWallet/Features/PLTTokenSupport/UnifiedToken.swift
+++ b/ConcordiumWallet/Features/PLTTokenSupport/UnifiedToken.swift
@@ -69,7 +69,7 @@ extension UnifiedToken {
         case .cis2(let token):
             return AccountDetailAccount.token(token: token, amount: "")
         case .plt(let pltToken):
-            return AccountDetailAccount.plt(token: AccountPLTToken(token: pltToken, tokenAccountState: TokenAccountState(balance: TokenBalance(decimals: 2, value: ""), state: TokenBalanceState(denyList: false))), amount: "")
+            return AccountDetailAccount.plt(token: AccountPLTToken(token: pltToken, tokenAccountState: TokenAccountState(balance: TokenBalance(decimals: 2, value: ""), state: TokenBalanceState(denyList: nil, allowList: nil))), amount: "")
         }
     }
 }

--- a/ConcordiumWallet/Model/AutoGenerated/AccountPLTToken.swift
+++ b/ConcordiumWallet/Model/AutoGenerated/AccountPLTToken.swift
@@ -57,6 +57,7 @@ struct TokenAccountState: Codable, Equatable, Hashable {
 
 struct TokenBalanceState: Codable, Equatable, Hashable {
     let denyList: Bool?
+    let allowList: Bool?
 }
 
 extension AccountPLTToken {
@@ -110,7 +111,7 @@ extension AccountPLTToken {
             value:    balanceObj.value ?? "0"
         )
 
-        let state = TokenBalanceState(denyList: stateObj?.denyList)
+        let state = TokenBalanceState(denyList: stateObj?.denyList, allowList: stateObj?.allowList)
 
         let tokenAccountState = TokenAccountState(balance: balance, state: state)
 

--- a/ConcordiumWallet/Service/AccountsService.swift
+++ b/ConcordiumWallet/Service/AccountsService.swift
@@ -413,7 +413,8 @@ class AccountsService: AccountsServiceProtocol, SubmissionStatusService {
                                 value: token.tokenAccountState.balance.value
                             ),
                             state: TokenBalanceState(
-                                denyList: token.tokenAccountState.state.denyList
+                                denyList: token.tokenAccountState.state.denyList,
+                                allowList: token.tokenAccountState.state.allowList
                             )
                         )
                     )

--- a/CryptoXDataModel.xcdatamodeld/CryptoXDataModel.xcdatamodel/contents
+++ b/CryptoXDataModel.xcdatamodeld/CryptoXDataModel.xcdatamodel/contents
@@ -27,6 +27,7 @@
         <relationship name="tokenState" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TokenStateEntity"/>
     </entity>
     <entity name="StateEntity" representedClassName="StateEntity" syncable="YES">
+        <attribute name="allowList" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="denyList" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
     </entity>
     <entity name="TokenAccountStateEntity" representedClassName="TokenAccountStateEntity" syncable="YES">


### PR DESCRIPTION
## Purpose

Display if the account for PLT is on allow or deny list based on the account token state. Show tokenID on main screen instead if the token name.

