### PR TITLE
make UI compatible with iOS 26

### DIFF
--- a/ConcordiumWallet/Resources/CryptoXMainNet-Info.plist
+++ b/ConcordiumWallet/Resources/CryptoXMainNet-Info.plist
@@ -6,6 +6,8 @@
 	<false/>
 	<key>API_KEY</key>
 	<string>6515da6d-a065-4676-a214-c83e5b18f5f3</string>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>MAINNET_WERT_API_KEY</key>
 	<string>wert-prod-0a3392b9c8aa1163334f5bdcef1b27e64593206d</string>
 	<key>MAINNET_WERT_PARTNER_ID</key>

--- a/ConcordiumWallet/Resources/CryptoXStagingNet-Info.plist
+++ b/ConcordiumWallet/Resources/CryptoXStagingNet-Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>FirebaseAutomaticScreenReportingEnabled</key>
 	<false/>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
 	<key>TESTNET_WERT_API_KEY</key>

--- a/ConcordiumWallet/Resources/ProdTestNet-Info.plist
+++ b/ConcordiumWallet/Resources/ProdTestNet-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>FirebaseAutomaticScreenReportingEnabled</key>
 	<false/>
 	<key>NSUserTrackingUsageDescription</key>


### PR DESCRIPTION
## Purpose

Make UI compatible with iOS 26. New Info.plist key is working now, but from what I found out it can be removed in the iOS 27, so we'll need to deal with it later.