### PR TITLE
Unify QR scanner logic - RocketFuel support

### DIFF
--- a/ConcordiumWallet/Core/Navigation/NavigationDestinationBuilder.swift
+++ b/ConcordiumWallet/Core/Navigation/NavigationDestinationBuilder.swift
@@ -51,7 +51,7 @@ struct NavigationDestinationBuilder: ViewModifier {
                         } else {
                             EmptyView()
                         }
-                    case .send(let account, let tokenType):
+                    case .send(let account, let tokenType, let address):
                         SendTokenView(path: $navigationManager.path,
                                       viewModel: .init(
                                         tokenType: tokenType,
@@ -66,6 +66,7 @@ struct NavigationDestinationBuilder: ViewModifier {
                                             onTxSuccess: { _ in },
                                             onTxReject: {}
                                         ),
+                                        recepientAddress: address,
                                         onRecipientPicked: onAddressPicked.eraseToAnyPublisher()))
                         .modifier(NavigationViewModifier(title: "Send", backAction: {
                             navigationManager.pop()

--- a/ConcordiumWallet/Core/Navigation/NavigationPathsEnum.swift
+++ b/ConcordiumWallet/Core/Navigation/NavigationPathsEnum.swift
@@ -14,7 +14,7 @@ enum NavigationPaths: Hashable {
     case manageTokens(_ viewModel: AccountsMainViewModel)
     case tokenDetails(token: AccountDetailAccount, _ viewModel: AccountDetailViewModel)
     case buy
-    case send(_ account: AccountEntity, tokenType: CXTokenType)
+    case send(_ account: AccountEntity, tokenType: CXTokenType, to: String?)
     case receive(_ account: AccountEntity)
     case activity(_ account: AccountEntity)
     case addToken(_ account: AccountEntity)

--- a/ConcordiumWallet/Features/AccountsMainView/AccountsMainRouter.swift
+++ b/ConcordiumWallet/Features/AccountsMainView/AccountsMainRouter.swift
@@ -186,10 +186,27 @@ extension AccountsMainRouter: CreateNewIdentityDelegate {
 }
 
 extension AccountsMainRouter: ScanAddressQRPresenterDelegate {
+    
+    private func selectedAccount() -> AccountEntity? {
+        let accounts = self.dependencyProvider.storageManager().getAccounts()
+        if let lastSelectedAccountAddress = AppSettings.lastSelectedAccountAddress {
+            return accounts.first(where: {$0.address == lastSelectedAccountAddress}) as? AccountEntity
+        } else {
+            return accounts.first as? AccountEntity
+        }
+    }
+    
     func scanAddressQr(didScan output: QRScannerOutput) {
         navigationController.popViewController(animated: true)
         switch output {
-            case .address: break
+        case let .address(address):
+            navigationController.dismiss(animated: true)
+            
+    
+            
+            if let account = self.selectedAccount() {
+                self.navigationManager.navigate(to: .send(account, tokenType: CXTokenType.ccd, to: address))
+            }
             case .airdrop(let string):
                 scanAddressQr(didScanAddress: string)
             case .connectURL(let string):

--- a/ConcordiumWallet/Features/NewAccountFlow/HomeScreen/HomeScreenView.swift
+++ b/ConcordiumWallet/Features/NewAccountFlow/HomeScreen/HomeScreenView.swift
@@ -463,7 +463,7 @@ struct HomeScreenView: View {
             }),
             ActionItem(iconName: "send", label: "Send", action: {
                 if let account = viewModel.selectedAccount?.account as? AccountEntity {
-                    navigationManager.navigate(to: .send(account, tokenType: .ccd))
+                    navigationManager.navigate(to: .send(account, tokenType: .ccd, to: nil))
                 }
             }),
             ActionItem(iconName: "receive", label: "Receive", action: {

--- a/ConcordiumWallet/Features/NewAccountFlow/TokenBalanceView.swift
+++ b/ConcordiumWallet/Features/NewAccountFlow/TokenBalanceView.swift
@@ -270,11 +270,11 @@ struct TokenBalanceView: View {
             ActionItem(iconName: "send", label: "Send", action: {
                 guard let account = viewModel.account as? AccountEntity else { return }
                 if token.name == "ccd" {
-                    path.append(.send(account, tokenType: .ccd))
+                    path.append(.send(account, tokenType: .ccd, to: nil))
                 } else if let token = token.cis2Token {
-                    path.append(.send(account, tokenType: .cis2(token)))
+                    path.append(.send(account, tokenType: .cis2(token), to: nil))
                 } else if let token = token.pltToken {
-                    path.append(.send(account, tokenType: .plt(token)))
+                    path.append(.send(account, tokenType: .plt(token), to: nil))
                 }
             }),
             ActionItem(iconName: "receive", label: "Receive", action: {

--- a/ConcordiumWallet/Features/TransferTokenFlow/Models/TransferTokenViewModel.swift
+++ b/ConcordiumWallet/Features/TransferTokenFlow/Models/TransferTokenViewModel.swift
@@ -116,6 +116,7 @@ final class TransferTokenViewModel: ObservableObject, Hashable, Equatable {
         account: AccountDataType,
         dependencyProvider: AccountsFlowCoordinatorDependencyProvider,
         tokenTransferModel: CIS2TokenTransferModel,
+        recepientAddress: String?,
         onRecipientPicked: AnyPublisher<String, Never>
     ) {
         self.tokenTransferModel = tokenTransferModel
@@ -201,6 +202,9 @@ final class TransferTokenViewModel: ObservableObject, Hashable, Equatable {
         }.store(in: &cancellables)
         
         updateChainParameters()
+        
+        self.recepientAddress = recepientAddress ?? ""
+        self.tokenTransferModel.recipient = recepientAddress
     }
     
     private func updateChainParameters() {

--- a/CryptoX.xcodeproj/project.pbxproj
+++ b/CryptoX.xcodeproj/project.pbxproj
@@ -8436,7 +8436,6 @@
 				08A0455829FA99D100DACE1F /* AccountReleaseSchedule.swift in Sources */,
 				088FEC8E2A01606100042957 /* StyledLabel.swift in Sources */,
 				088FF14E2A02883C00042957 /* UITableView+Extensions.swift in Sources */,
-				158A35A92E1BC57100BDCFDE /* CryptoXDataModel.xcdatamodeld in Sources */,
 				088FEF992A02715100042957 /* SelectIdentityViewModel.swift in Sources */,
 				08A0458529FA99D100DACE1F /* GeneratedBakerKeys.swift in Sources */,
 				088FEF522A0270AF00042957 /* IdentityRevokersWidgetPresenter.swift in Sources */,


### PR DESCRIPTION
## Users often use the home scanner to pay, which silently fails. This is a critical UX bug for RocketFuel and future integrations.

Unify scanning logic. The main (home) scanner should handle all supported QR types and route accordingly:
- Wallet Connect QR: continue with the wallet connect flow.
- Payment QR (CCD / RocketFuel, etc.): open Send flow with recipient and amount prefilled.
- Unknown/invalid QR: show error message with clear CTA (“Unsupported QR code”).

