### PR TITLE
Change cost calculation of wallet-connect transaction proposals to local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased 3.5.1]
+## Unreleased
+- Change contract update cost calculation to local computation instead of relying on the wallet proxy.
+
+## [Released 3.5.1]
+
 ### Updates:
 - Added suppport for configure delegation and smart contract sponsored transactions
 - Refactored WalletConnect & QR Code Scanner Flow 

--- a/ConcordiumWallet/Features/WalletConnect/SessionRequestFlow/DataModels/TransferUpdateRequestModel.swift
+++ b/ConcordiumWallet/Features/WalletConnect/SessionRequestFlow/DataModels/TransferUpdateRequestModel.swift
@@ -48,7 +48,8 @@ final class TransferUpdateRequestModel: SessionRequestDataProvidable {
     @MainActor
     func approveRequest() async throws {
         let params = try sessionRequest.params.get(ContractUpdateRequestParams.self)
-        let transfer = getTransfer(for: params)
+        let txCost = try await getLocalContractUpdateCost(params: params)
+        let transfer = getTransfer(for: params, energy: txCost.energy)
         let result = try await createAndPerform(params: params, account: account, transfer: transfer).singleOutput()
         try await Sign.instance.respond(
             topic: sessionRequest.topic,
@@ -60,24 +61,10 @@ final class TransferUpdateRequestModel: SessionRequestDataProvidable {
     
     @MainActor
     func checkBalance(account: AccountEntity, params: ContractUpdateRequestParams) async throws -> Bool {
-        let transfer = self.getTransfer(for: params)
-        let txCost = try await transactionsService.getTransferCost(
-            transferType: transfer.transferType.toWalletProxyTransferType(),
-            costParameters: params.costParameters()
-        ).async()
-        let nrgCCDAmount = self.getNrgCCDAmount(
-            nrgLimit: params.payload.maxContractExecutionEnergy,
-            cost: txCost.cost.floatValue,
-            energy: txCost.energy.string.floatValue
-        )
-        
+        let txCost = try await getLocalContractUpdateCost(params: params)
         let amount = Int(params.payload.amount) ?? 0
-        let ccdAmount =  GTU(intValue: amount)
-        let ccdNetworkComission = GTU(displayValue: nrgCCDAmount.toString())
-        let ccdTotalAmount = GTU(intValue: ccdAmount.intValue + ccdNetworkComission.intValue)
-        let ccdTotalBalance = GTU(intValue: account.forecastBalance)
-        
-        return ccdTotalBalance.intValue > ccdTotalAmount.intValue
+        let transactionCost = Int(txCost.cost) ?? 0
+        return account.forecastBalance > amount + transactionCost
     }
     
     @MainActor
@@ -91,13 +78,48 @@ final class TransferUpdateRequestModel: SessionRequestDataProvidable {
             .eraseToAnyPublisher()
     }
     
-    private func getNrgCCDAmount(nrgLimit: Int, cost: Float, energy: Float) -> Int {
-        let _nrgLimit = Float(nrgLimit)
-        let nrgCCDAmount = Float(_nrgLimit * (cost / energy) / 1000000.0)
-        return Int(ceil(nrgCCDAmount))
+    private func getLocalContractUpdateCost(params: ContractUpdateRequestParams) async throws -> TransferCost {
+        guard let transactionsService = transactionsService as? TransactionsService else {
+            throw SessionRequstError.generic("Unsupported transaction service")
+        }
+
+        let chainParameters = try await transactionsService.getChainParameters().async()
+        let energy = calculateContractUpdateEnergy(params: params)
+        let cost = calculateMicroCcdCost(energy: energy, chainParameters: chainParameters)
+        return TransferCost(energy: energy, cost: cost.toString())
+    }
+
+    private func calculateContractUpdateEnergy(params: ContractUpdateRequestParams) -> Int {
+        let signatureCount = 1
+        let accountTransactionHeaderSize = 32 + 8 + 8 + 4 + 8
+        let payloadSize = 8 + 16 + 2 + byteCount(hex: params.payload.message) + 2 + params.payload.receiveName.utf8.count
+        return 100 * signatureCount + accountTransactionHeaderSize + payloadSize + params.payload.maxContractExecutionEnergy
+    }
+
+    private func calculateMicroCcdCost(energy: Int, chainParameters: ChainParametersResponse) -> Int {
+        let numerator = Decimal(energy)
+            * Decimal(chainParameters.euroPerEnergy.numerator)
+            * Decimal(chainParameters.microGTUPerEuro.numerator)
+        let denominator = Decimal(chainParameters.euroPerEnergy.denominator)
+            * Decimal(chainParameters.microGTUPerEuro.denominator)
+        let decimalCost = NSDecimalNumber(decimal: numerator / denominator)
+        let roundedCost = decimalCost.rounding(accordingToBehavior: NSDecimalNumberHandler(
+            roundingMode: .up,
+            scale: 0,
+            raiseOnExactness: false,
+            raiseOnOverflow: false,
+            raiseOnUnderflow: false,
+            raiseOnDivideByZero: false
+        ))
+        return roundedCost.intValue
+    }
+
+    private func byteCount(hex: String) -> Int {
+        let hexString = hex.hasPrefix("0x") ? String(hex.dropFirst(2)) : hex
+        return (hexString.utf8.count + 1) / 2
     }
     
-    private func getTransfer(for params: ContractUpdateRequestParams) -> any TransferDataType {
+    private func getTransfer(for params: ContractUpdateRequestParams, energy: Int) -> any TransferDataType {
         var transfer = TransferDataTypeFactory.create()
         transfer.transferType = params.type
         transfer.amount = params.payload.amount
@@ -105,7 +127,7 @@ final class TransferUpdateRequestModel: SessionRequestDataProvidable {
         transfer.from = params.sender
         transfer.toAddress = params.sender
         transfer.expiry = Date().addingTimeInterval(10 * 60)
-        transfer.energy = params.payload.maxContractExecutionEnergy
+        transfer.energy = energy
         transfer.receiveName = params.payload.receiveName
         transfer.params = params.payload.message
         transfer.contractAddressObject = ContractAddressObject()

--- a/ConcordiumWallet/Features/WalletConnect/SessionRequestFlow/DataModels/TransferUpdateRequestModel.swift
+++ b/ConcordiumWallet/Features/WalletConnect/SessionRequestFlow/DataModels/TransferUpdateRequestModel.swift
@@ -84,19 +84,37 @@ final class TransferUpdateRequestModel: SessionRequestDataProvidable {
         }
 
         let chainParameters = try await transactionsService.getChainParameters().async()
-        let energy = calculateContractUpdateEnergy(params: params)
-        let cost = calculateMicroCcdCost(energy: energy, chainParameters: chainParameters)
+        let energy = try calculateContractUpdateEnergy(params: params)
+        let cost = try calculateMicroCcdCost(energy: energy, chainParameters: chainParameters)
         return TransferCost(energy: energy, cost: cost.toString())
     }
 
-    private func calculateContractUpdateEnergy(params: ContractUpdateRequestParams) -> Int {
+    private func calculateContractUpdateEnergy(params: ContractUpdateRequestParams) throws -> Int {
+        guard params.payload.maxContractExecutionEnergy >= 0 else {
+            throw SessionRequstError.generic("Invalid max contract execution energy")
+        }
+
         let signatureCount = 1
+        // Account transaction header: account address (32), nonce (8), energy (8), payload size (4), expiry (8).
         let accountTransactionHeaderSize = 32 + 8 + 8 + 4 + 8
+        // Update contract payload: amount (8), contract address (16), receive name size (2), parameter size (2).
         let payloadSize = 8 + 16 + 2 + byteCount(hex: params.payload.message) + 2 + params.payload.receiveName.utf8.count
-        return 100 * signatureCount + accountTransactionHeaderSize + payloadSize + params.payload.maxContractExecutionEnergy
+        // Base energy formula: A * signatures + B * (header size + payload size) + contract execution energy.
+        // Protocol constants A = 100 and B = 1.
+        let signatureEnergy = try checkedMultiply(100, signatureCount)
+        let verificationEnergy = try checkedAdd(signatureEnergy, accountTransactionHeaderSize)
+        let transactionEnergy = try checkedAdd(verificationEnergy, payloadSize)
+        return try checkedAdd(transactionEnergy, params.payload.maxContractExecutionEnergy)
     }
 
-    private func calculateMicroCcdCost(energy: Int, chainParameters: ChainParametersResponse) -> Int {
+    private func calculateMicroCcdCost(energy: Int, chainParameters: ChainParametersResponse) throws -> Int {
+        guard energy >= 0 else {
+            throw SessionRequstError.generic("Invalid transaction energy")
+        }
+        guard chainParameters.euroPerEnergy.denominator > 0, chainParameters.microGTUPerEuro.denominator > 0 else {
+            throw SessionRequstError.generic("Invalid chain parameter denominator")
+        }
+
         let numerator = Decimal(energy)
             * Decimal(chainParameters.euroPerEnergy.numerator)
             * Decimal(chainParameters.microGTUPerEuro.numerator)
@@ -111,7 +129,27 @@ final class TransferUpdateRequestModel: SessionRequestDataProvidable {
             raiseOnUnderflow: false,
             raiseOnDivideByZero: false
         ))
+        guard roundedCost.doubleValue.isFinite,
+              roundedCost.compare(NSDecimalNumber(value: Int.max)) != .orderedDescending else {
+            throw SessionRequstError.generic("Transaction cost exceeds supported range")
+        }
         return roundedCost.intValue
+    }
+
+    private func checkedAdd(_ lhs: Int, _ rhs: Int) throws -> Int {
+        let result = lhs.addingReportingOverflow(rhs)
+        guard !result.overflow else {
+            throw SessionRequstError.generic("Transaction energy exceeds supported range")
+        }
+        return result.partialValue
+    }
+
+    private func checkedMultiply(_ lhs: Int, _ rhs: Int) throws -> Int {
+        let result = lhs.multipliedReportingOverflow(by: rhs)
+        guard !result.overflow else {
+            throw SessionRequstError.generic("Transaction energy exceeds supported range")
+        }
+        return result.partialValue
     }
 
     private func byteCount(hex: String) -> Int {

--- a/ConcordiumWallet/Service/TransactionsService.swift
+++ b/ConcordiumWallet/Service/TransactionsService.swift
@@ -54,6 +54,11 @@ class TransactionsService: TransactionsServiceProtocol, SubmissionStatusService 
         let request = ResourceRequest(url: ApiConstants.transferCost, parameters: params)
         return networkManager.load(request)
     }
+
+    func getChainParameters() -> AnyPublisher<ChainParametersResponse, Error> {
+        let request = ResourceRequest(url: ApiConstants.chainParameters)
+        return networkManager.load(request)
+    }
     
     func performTransfer(_ pTransfer: TransferDataType,
                          from account: AccountDataType,

--- a/CryptoX.xcodeproj/project.pbxproj
+++ b/CryptoX.xcodeproj/project.pbxproj
@@ -9670,7 +9670,7 @@
 			repositoryURL = "https://github.com/Concordium/concordium-swift-sdk.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.4.0;
+				minimumVersion = 1.4.1;
 			};
 		};
 		5032DC742E9E35460051F548 /* XCRemoteSwiftPackageReference "SwiftCBOR" */ = {

--- a/CryptoX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CryptoX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Concordium/concordium-swift-sdk.git",
       "state" : {
-        "revision" : "60c9bb08de4377874505c6a6524450c8b08412a4",
-        "version" : "1.4.0"
+        "revision" : "0907c6fe146a574138b803bb168e022b0befacd0",
+        "version" : "1.4.1"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "52548902007e7beda99fcdca31f62eccc4befe38",
-        "version" : "12.11.0"
+        "revision" : "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
+        "version" : "11.15.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "7b722132d1f2ab421c88a2e5c384c984cebd0d00",
-        "version" : "3.4.0"
+        "revision" : "a2d0f1f1666de591eb1a811f40b1706f5c63a2ed",
+        "version" : "2.3.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "1657f705bc70255ff9d66dfcc697a85db164998f",
-        "version" : "12.11.0"
+        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.15.0"
       }
     },
     {


### PR DESCRIPTION
Fixes an issue where huge contract parameters received through wallet-connect causes the wallet to disable signing due to GET request limits imposed by the wallet proxy when behind certain types of load balancers.

This also aligns the transaction cost model with the implementation in the android wallet.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
